### PR TITLE
Add secondary normalizer class without typehints.

### DIFF
--- a/src/Normalizer/AddressValidation/CandidateAddressKeyFormatNormalizer.php
+++ b/src/Normalizer/AddressValidation/CandidateAddressKeyFormatNormalizer.php
@@ -27,7 +27,7 @@ if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR
         }
     }
 } else {
-    class CandidateADdressKeyFormatNormalizer extends BaseNormalizer
+    class CandidateAddressKeyFormatNormalizer extends BaseNormalizer
     {
         /**
          * @inheritDoc

--- a/src/Normalizer/AddressValidation/CandidateAddressKeyFormatNormalizer.php
+++ b/src/Normalizer/AddressValidation/CandidateAddressKeyFormatNormalizer.php
@@ -3,24 +3,47 @@
 namespace ShipStream\Ups\Normalizer\AddressValidation;
 
 use ShipStream\Ups\Api\Normalizer\CandidateAddressKeyFormatNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function is_array;
 
-class CandidateAddressKeyFormatNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class CandidateAddressKeyFormatNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force AddressLine to always be an array even when the API returns a single value
+            // @see https://github.com/UPS-API/api-documentation/issues/3
+            if (isset($data['AddressLine']) && ! is_array($data['AddressLine'])) {
+                $data['AddressLine'] = [$data['AddressLine']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class CandidateADdressKeyFormatNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force AddressLine to always be an array even when the API returns a single value
-        // @see https://github.com/UPS-API/api-documentation/issues/3
-        if (isset($data['AddressLine']) && ! is_array($data['AddressLine'])) {
-            $data['AddressLine'] = [$data['AddressLine']];
+            // Force AddressLine to always be an array even when the API returns a single value
+            // @see https://github.com/UPS-API/api-documentation/issues/3
+            if (isset($data['AddressLine']) && ! is_array($data['AddressLine'])) {
+                $data['AddressLine'] = [$data['AddressLine']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/AddressValidation/XAVResponseCandidateNormalizer.php
+++ b/src/Normalizer/AddressValidation/XAVResponseCandidateNormalizer.php
@@ -3,28 +3,51 @@
 namespace ShipStream\Ups\Normalizer\AddressValidation;
 
 use ShipStream\Ups\Api\Normalizer\XAVResponseCandidateNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
 /**
  * Custom deserializer for "Candidate" object.
  */
-class XAVResponseCandidateNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class XAVResponseCandidateNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force AddressKeyFormat to always be an array even when the API returns a single value
+            // @see https://github.com/UPS-API/api-documentation/issues/3
+            if (isset($data['AddressKeyFormat']) && !array_is_list($data['AddressKeyFormat'])) {
+                $data['AddressKeyFormat'] = [$data['AddressKeyFormat']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class XAVResponseCandidateNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force AddressKeyFormat to always be an array even when the API returns a single value
-        // @see https://github.com/UPS-API/api-documentation/issues/3
-        if (isset($data['AddressKeyFormat']) && ! array_is_list($data['AddressKeyFormat'])) {
-            $data['AddressKeyFormat'] = [$data['AddressKeyFormat']];
+            // Force AddressKeyFormat to always be an array even when the API returns a single value
+            // @see https://github.com/UPS-API/api-documentation/issues/3
+            if (isset($data['AddressKeyFormat']) && !array_is_list($data['AddressKeyFormat'])) {
+                $data['AddressKeyFormat'] = [$data['AddressKeyFormat']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/DangerousGoods/AcceptanceAuditPreCheckResponseNormalizer.php
+++ b/src/Normalizer/DangerousGoods/AcceptanceAuditPreCheckResponseNormalizer.php
@@ -3,24 +3,46 @@
 namespace ShipStream\Ups\Normalizer\DangerousGoods;
 
 use ShipStream\Ups\Api\Normalizer\AcceptanceAuditPreCheckResponseNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class AcceptanceAuditPreCheckResponseNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class AcceptanceAuditPreCheckResponseNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force PackageResults to always be an array even when the API returns a single value
+            if (isset($data['PackageResults']) && !array_is_list($data['PackageResults'])) {
+                $data['PackageResults'] = [$data['PackageResults']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class AcceptanceAuditPreCheckResponseNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force PackageResults to always be an array even when the API returns a single value
-        if (isset($data['PackageResults']) && ! array_is_list($data['PackageResults'])) {
-            $data['PackageResults'] = [$data['PackageResults']];
+            // Force PackageResults to always be an array even when the API returns a single value
+            if (isset($data['PackageResults']) && !array_is_list($data['PackageResults'])) {
+                $data['PackageResults'] = [$data['PackageResults']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/DangerousGoods/AcceptanceAuditPreCheckResponsePackageResultsNormalizer.php
+++ b/src/Normalizer/DangerousGoods/AcceptanceAuditPreCheckResponsePackageResultsNormalizer.php
@@ -3,24 +3,46 @@
 namespace ShipStream\Ups\Normalizer\DangerousGoods;
 
 use ShipStream\Ups\Api\Normalizer\AcceptanceAuditPreCheckResponsePackageResultsNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class AcceptanceAuditPreCheckResponsePackageResultsNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class AcceptanceAuditPreCheckResponsePackageResultsNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force ChemicalRecordResults to always be an array even when the API returns a single value
+            if (isset($data['ChemicalRecordResults']) && !array_is_list($data['ChemicalRecordResults'])) {
+                $data['ChemicalRecordResults'] = [$data['ChemicalRecordResults']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class AcceptanceAuditPreCheckResponsePackageResultsNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force ChemicalRecordResults to always be an array even when the API returns a single value
-        if (isset($data['ChemicalRecordResults']) && ! array_is_list($data['ChemicalRecordResults'])) {
-            $data['ChemicalRecordResults'] = [$data['ChemicalRecordResults']];
+            // Force ChemicalRecordResults to always be an array even when the API returns a single value
+            if (isset($data['ChemicalRecordResults']) && !array_is_list($data['ChemicalRecordResults'])) {
+                $data['ChemicalRecordResults'] = [$data['ChemicalRecordResults']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/DangerousGoods/AcceptanceAuditPreCheckResponseResponseNormalizer.php
+++ b/src/Normalizer/DangerousGoods/AcceptanceAuditPreCheckResponseResponseNormalizer.php
@@ -3,27 +3,52 @@
 namespace ShipStream\Ups\Normalizer\DangerousGoods;
 
 use ShipStream\Ups\Api\Normalizer\AcceptanceAuditPreCheckResponseResponseNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class AcceptanceAuditPreCheckResponseResponseNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class AcceptanceAuditPreCheckResponseResponseNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force Alert & AlertDetail to always be an array even when the API returns a single value
+            if (isset($data['Alert']) && !array_is_list($data['Alert'])) {
+                $data['Alert'] = [$data['Alert']];
+            }
+            if (isset($data['AlertDetail']) && !array_is_list($data['AlertDetail'])) {
+                $data['AlertDetail'] = [$data['AlertDetail']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class AcceptanceAuditPreCheckResponseResponseNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force Alert & AlertDetail to always be an array even when the API returns a single value
-        if (isset($data['Alert']) && ! array_is_list($data['Alert'])) {
-            $data['Alert'] = [$data['Alert']];
+            // Force Alert & AlertDetail to always be an array even when the API returns a single value
+            if (isset($data['Alert']) && !array_is_list($data['Alert'])) {
+                $data['Alert'] = [$data['Alert']];
+            }
+            if (isset($data['AlertDetail']) && !array_is_list($data['AlertDetail'])) {
+                $data['AlertDetail'] = [$data['AlertDetail']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        if (isset($data['AlertDetail']) && ! array_is_list($data['AlertDetail'])) {
-            $data['AlertDetail'] = [$data['AlertDetail']];
-        }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/DangerousGoods/ChemicalReferenceDataResponseChemicalDataNormalizer.php
+++ b/src/Normalizer/DangerousGoods/ChemicalReferenceDataResponseChemicalDataNormalizer.php
@@ -3,24 +3,46 @@
 namespace ShipStream\Ups\Normalizer\DangerousGoods;
 
 use ShipStream\Ups\Api\Normalizer\ChemicalReferenceDataResponseChemicalDataNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class ChemicalReferenceDataResponseChemicalDataNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class ChemicalReferenceDataResponseChemicalDataNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force PackageQuantityLimitDetail to always be an array even when the API returns a single value
+            if (isset($data['PackageQuantityLimitDetail']) && !array_is_list($data['PackageQuantityLimitDetail'])) {
+                $data['PackageQuantityLimitDetail'] = [$data['PackageQuantityLimitDetail']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class ChemicalReferenceDataResponseChemicalDataNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force PackageQuantityLimitDetail to always be an array even when the API returns a single value
-        if (isset($data['PackageQuantityLimitDetail']) && ! array_is_list($data['PackageQuantityLimitDetail'])) {
-            $data['PackageQuantityLimitDetail'] = [$data['PackageQuantityLimitDetail']];
+            // Force PackageQuantityLimitDetail to always be an array even when the API returns a single value
+            if (isset($data['PackageQuantityLimitDetail']) && !array_is_list($data['PackageQuantityLimitDetail'])) {
+                $data['PackageQuantityLimitDetail'] = [$data['PackageQuantityLimitDetail']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/DangerousGoods/ChemicalReferenceDataResponseNormalizer.php
+++ b/src/Normalizer/DangerousGoods/ChemicalReferenceDataResponseNormalizer.php
@@ -3,24 +3,46 @@
 namespace ShipStream\Ups\Normalizer\DangerousGoods;
 
 use ShipStream\Ups\Api\Normalizer\ChemicalReferenceDataResponseNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class ChemicalReferenceDataResponseNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class ChemicalReferenceDataResponseNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force ChemicalData to always be an array even when the API returns a single value
+            if (isset($data['ChemicalData']) && !array_is_list($data['ChemicalData'])) {
+                $data['ChemicalData'] = [$data['ChemicalData']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class ChemicalReferenceDataResponseNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force ChemicalData to always be an array even when the API returns a single value
-        if (isset($data['ChemicalData']) && ! array_is_list($data['ChemicalData'])) {
-            $data['ChemicalData'] = [$data['ChemicalData']];
+            // Force ChemicalData to always be an array even when the API returns a single value
+            if (isset($data['ChemicalData']) && !array_is_list($data['ChemicalData'])) {
+                $data['ChemicalData'] = [$data['ChemicalData']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/DangerousGoods/ChemicalReferenceDataResponseResponseNormalizer.php
+++ b/src/Normalizer/DangerousGoods/ChemicalReferenceDataResponseResponseNormalizer.php
@@ -3,24 +3,46 @@
 namespace ShipStream\Ups\Normalizer\DangerousGoods;
 
 use ShipStream\Ups\Api\Normalizer\ChemicalReferenceDataResponseResponseNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class ChemicalReferenceDataResponseResponseNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class ChemicalReferenceDataResponseResponseNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force Alert to always be an array even when the API returns a single value
+            if (isset($data['Alert']) && !array_is_list($data['Alert'])) {
+                $data['Alert'] = [$data['Alert']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class ChemicalReferenceDataResponseResponseNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force Alert to always be an array even when the API returns a single value
-        if (isset($data['Alert']) && ! array_is_list($data['Alert'])) {
-            $data['Alert'] = [$data['Alert']];
+            // Force Alert to always be an array even when the API returns a single value
+            if (isset($data['Alert']) && !array_is_list($data['Alert'])) {
+                $data['Alert'] = [$data['Alert']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/LandedCost/LandedCostResponseShipmentNormalizer.php
+++ b/src/Normalizer/LandedCost/LandedCostResponseShipmentNormalizer.php
@@ -3,24 +3,46 @@
 namespace ShipStream\Ups\Normalizer\LandedCost;
 
 use ShipStream\Ups\Api\Normalizer\LandedCostResponseShipmentNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class LandedCostResponseShipmentNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class LandedCostResponseShipmentNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force shipmentItems to always be an array even when the API returns a single value
+            if (isset($data['shipmentItems']) && !array_is_list($data['shipmentItems'])) {
+                $data['shipmentItems'] = [$data['shipmentItems']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class LandedCostResponseShipmentNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force shipmentItems to always be an array even when the API returns a single value
-        if (isset($data['shipmentItems']) && ! array_is_list($data['shipmentItems'])) {
-            $data['shipmentItems'] = [$data['shipmentItems']];
+            // Force shipmentItems to always be an array even when the API returns a single value
+            if (isset($data['shipmentItems']) && !array_is_list($data['shipmentItems'])) {
+                $data['shipmentItems'] = [$data['shipmentItems']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/Locator/AccessPointInformationBusinessClassificationListNormalizer.php
+++ b/src/Normalizer/Locator/AccessPointInformationBusinessClassificationListNormalizer.php
@@ -3,24 +3,46 @@
 namespace ShipStream\Ups\Normalizer\Locator;
 
 use ShipStream\Ups\Api\Normalizer\AccessPointInformationBusinessClassificationListNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class AccessPointInformationBusinessClassificationListNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class AccessPointInformationBusinessClassificationListNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force BusinessClassification to always be an array even when the API returns a single value
+            if (isset($data['BusinessClassification']) && !array_is_list($data['BusinessClassification'])) {
+                $data['BusinessClassification'] = [$data['BusinessClassification']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class AccessPointInformationBusinessClassificationListNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force BusinessClassification to always be an array even when the API returns a single value
-        if (isset($data['BusinessClassification']) && ! array_is_list($data['BusinessClassification'])) {
-            $data['BusinessClassification'] = [$data['BusinessClassification']];
+            // Force BusinessClassification to always be an array even when the API returns a single value
+            if (isset($data['BusinessClassification']) && !array_is_list($data['BusinessClassification'])) {
+                $data['BusinessClassification'] = [$data['BusinessClassification']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/Locator/AccessPointInformationPrivateNetworkListNormalizer.php
+++ b/src/Normalizer/Locator/AccessPointInformationPrivateNetworkListNormalizer.php
@@ -3,24 +3,46 @@
 namespace ShipStream\Ups\Normalizer\Locator;
 
 use ShipStream\Ups\Api\Normalizer\AccessPointInformationPrivateNetworkListNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class AccessPointInformationPrivateNetworkListNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class AccessPointInformationPrivateNetworkListNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force PrivateNetwork to always be an array even when the API returns a single value
+            if (isset($data['PrivateNetwork']) && !array_is_list($data['PrivateNetwork'])) {
+                $data['PrivateNetwork'] = [$data['PrivateNetwork']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class AccessPointInformationPrivateNetworkListNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force PrivateNetwork to always be an array even when the API returns a single value
-        if (isset($data['PrivateNetwork']) && ! array_is_list($data['PrivateNetwork'])) {
-            $data['PrivateNetwork'] = [$data['PrivateNetwork']];
+            // Force PrivateNetwork to always be an array even when the API returns a single value
+            if (isset($data['PrivateNetwork']) && !array_is_list($data['PrivateNetwork'])) {
+                $data['PrivateNetwork'] = [$data['PrivateNetwork']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/Locator/DropLocationAdditionalCommentsNormalizer.php
+++ b/src/Normalizer/Locator/DropLocationAdditionalCommentsNormalizer.php
@@ -3,24 +3,46 @@
 namespace ShipStream\Ups\Normalizer\Locator;
 
 use ShipStream\Ups\Api\Normalizer\DropLocationAdditionalCommentsNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class DropLocationAdditionalCommentsNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class DropLocationAdditionalCommentsNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force CommentType to always be an array even when the API returns a single value
+            if (isset($data['CommentType']) && !array_is_list($data['CommentType'])) {
+                $data['CommentType'] = [$data['CommentType']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class DropLocationAdditionalCommentsNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force CommentType to always be an array even when the API returns a single value
-        if (isset($data['CommentType']) && ! array_is_list($data['CommentType'])) {
-            $data['CommentType'] = [$data['CommentType']];
+            // Force CommentType to always be an array even when the API returns a single value
+            if (isset($data['CommentType']) && !array_is_list($data['CommentType'])) {
+                $data['CommentType'] = [$data['CommentType']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/Locator/DropLocationLocationAttributeNormalizer.php
+++ b/src/Normalizer/Locator/DropLocationLocationAttributeNormalizer.php
@@ -3,24 +3,46 @@
 namespace ShipStream\Ups\Normalizer\Locator;
 
 use ShipStream\Ups\Api\Normalizer\DropLocationLocationAttributeNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class DropLocationLocationAttributeNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class DropLocationLocationAttributeNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force OptionCode to always be an array even when the API returns a single value
+            if (isset($data['OptionCode']) && !array_is_list($data['OptionCode'])) {
+                $data['OptionCode'] = [$data['OptionCode']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class DropLocationLocationAttributeNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force OptionCode to always be an array even when the API returns a single value
-        if (isset($data['OptionCode']) && ! array_is_list($data['OptionCode'])) {
-            $data['OptionCode'] = [$data['OptionCode']];
+            // Force OptionCode to always be an array even when the API returns a single value
+            if (isset($data['OptionCode']) && !array_is_list($data['OptionCode'])) {
+                $data['OptionCode'] = [$data['OptionCode']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/Locator/DropLocationOperatingHoursNormalizer.php
+++ b/src/Normalizer/Locator/DropLocationOperatingHoursNormalizer.php
@@ -3,24 +3,46 @@
 namespace ShipStream\Ups\Normalizer\Locator;
 
 use ShipStream\Ups\Api\Normalizer\DropLocationOperatingHoursNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class DropLocationOperatingHoursNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class DropLocationOperatingHoursNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force StandardHours to always be an array even when the API returns a single value
+            if (isset($data['StandardHours']) && !array_is_list($data['StandardHours'])) {
+                $data['StandardHours'] = [$data['StandardHours']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class DropLocationOperatingHoursNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force StandardHours to always be an array even when the API returns a single value
-        if (isset($data['StandardHours']) && ! array_is_list($data['StandardHours'])) {
-            $data['StandardHours'] = [$data['StandardHours']];
+            // Force StandardHours to always be an array even when the API returns a single value
+            if (isset($data['StandardHours']) && !array_is_list($data['StandardHours'])) {
+                $data['StandardHours'] = [$data['StandardHours']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/Locator/DropLocationServiceOfferingListNormalizer.php
+++ b/src/Normalizer/Locator/DropLocationServiceOfferingListNormalizer.php
@@ -3,24 +3,46 @@
 namespace ShipStream\Ups\Normalizer\Locator;
 
 use ShipStream\Ups\Api\Normalizer\DropLocationServiceOfferingListNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class DropLocationServiceOfferingListNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class DropLocationServiceOfferingListNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force ServiceOffering to always be an array even when the API returns a single value
+            if (isset($data['ServiceOffering']) && !array_is_list($data['ServiceOffering'])) {
+                $data['ServiceOffering'] = [$data['ServiceOffering']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class DropLocationServiceOfferingListNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force ServiceOffering to always be an array even when the API returns a single value
-        if (isset($data['ServiceOffering']) && ! array_is_list($data['ServiceOffering'])) {
-            $data['ServiceOffering'] = [$data['ServiceOffering']];
+            // Force ServiceOffering to always be an array even when the API returns a single value
+            if (isset($data['ServiceOffering']) && !array_is_list($data['ServiceOffering'])) {
+                $data['ServiceOffering'] = [$data['ServiceOffering']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/Locator/LocatorResponseSearchResultsNormalizer.php
+++ b/src/Normalizer/Locator/LocatorResponseSearchResultsNormalizer.php
@@ -3,30 +3,58 @@
 namespace ShipStream\Ups\Normalizer\Locator;
 
 use ShipStream\Ups\Api\Normalizer\LocatorResponseSearchResultsNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class LocatorResponseSearchResultsNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class LocatorResponseSearchResultsNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force attributes to always be an array even when the API returns a single value
+            if (isset($data['GeocodeCandidate']) && !array_is_list($data['GeocodeCandidate'])) {
+                $data['GeocodeCandidate'] = [$data['GeocodeCandidate']];
+            }
+            if (isset($data['Disclaimer']) && !array_is_list($data['Disclaimer'])) {
+                $data['Disclaimer'] = [$data['Disclaimer']];
+            }
+            if (isset($data['AvailableLocationAttributes']) && !array_is_list($data['AvailableLocationAttributes'])) {
+                $data['AvailableLocationAttributes'] = [$data['AvailableLocationAttributes']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class LocatorResponseSearchResultsNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force attributes to always be an array even when the API returns a single value
-        if (isset($data['GeocodeCandidate']) && ! array_is_list($data['GeocodeCandidate'])) {
-            $data['GeocodeCandidate'] = [$data['GeocodeCandidate']];
+            // Force attributes to always be an array even when the API returns a single value
+            if (isset($data['GeocodeCandidate']) && !array_is_list($data['GeocodeCandidate'])) {
+                $data['GeocodeCandidate'] = [$data['GeocodeCandidate']];
+            }
+            if (isset($data['Disclaimer']) && !array_is_list($data['Disclaimer'])) {
+                $data['Disclaimer'] = [$data['Disclaimer']];
+            }
+            if (isset($data['AvailableLocationAttributes']) && !array_is_list($data['AvailableLocationAttributes'])) {
+                $data['AvailableLocationAttributes'] = [$data['AvailableLocationAttributes']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        if (isset($data['Disclaimer']) && ! array_is_list($data['Disclaimer'])) {
-            $data['Disclaimer'] = [$data['Disclaimer']];
-        }
-        if (isset($data['AvailableLocationAttributes']) && ! array_is_list($data['AvailableLocationAttributes'])) {
-            $data['AvailableLocationAttributes'] = [$data['AvailableLocationAttributes']];
-        }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/Locator/OptionCodeTransportationPickUpScheduleNormalizer.php
+++ b/src/Normalizer/Locator/OptionCodeTransportationPickUpScheduleNormalizer.php
@@ -3,24 +3,46 @@
 namespace ShipStream\Ups\Normalizer\Locator;
 
 use ShipStream\Ups\Api\Normalizer\OptionCodeTransportationPickUpScheduleNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class OptionCodeTransportationPickUpScheduleNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class OptionCodeTransportationPickUpScheduleNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force PickUp to always be an array even when the API returns a single value
+            if (isset($data['PickUp']) && !array_is_list($data['PickUp'])) {
+                $data['PickUp'] = [$data['PickUp']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class OptionCodeTransportationPickUpScheduleNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force PickUp to always be an array even when the API returns a single value
-        if (isset($data['PickUp']) && ! array_is_list($data['PickUp'])) {
-            $data['PickUp'] = [$data['PickUp']];
+            // Force PickUp to always be an array even when the API returns a single value
+            if (isset($data['PickUp']) && !array_is_list($data['PickUp'])) {
+                $data['PickUp'] = [$data['PickUp']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/Locator/SearchResultsDropLocationNormalizer.php
+++ b/src/Normalizer/Locator/SearchResultsDropLocationNormalizer.php
@@ -3,45 +3,88 @@
 namespace ShipStream\Ups\Normalizer\Locator;
 
 use ShipStream\Ups\Api\Normalizer\SearchResultsDropLocationNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class SearchResultsDropLocationNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class SearchResultsDropLocationNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force attributes to always be an array even when the API returns a single value
+            if (isset($data['PhoneNumber']) && !is_array($data['PhoneNumber'])) {
+                $data['PhoneNumber'] = [$data['PhoneNumber']];
+            }
+            if (isset($data['LocationAttribute']) && !array_is_list($data['LocationAttribute'])) {
+                $data['LocationAttribute'] = [$data['LocationAttribute']];
+            }
+            if (isset($data['SpecialInstructions']) && !array_is_list($data['SpecialInstructions'])) {
+                $data['SpecialInstructions'] = [$data['SpecialInstructions']];
+            }
+            if (isset($data['LatestGroundDropOffTime']) && !is_array($data['LatestGroundDropOffTime'])) {
+                $data['LatestGroundDropOffTime'] = [$data['LatestGroundDropOffTime']];
+            }
+            if (isset($data['LatestAirDropOffTime']) && !is_array($data['LatestAirDropOffTime'])) {
+                $data['LatestAirDropOffTime'] = [$data['LatestAirDropOffTime']];
+            }
+            if (isset($data['Disclaimer']) && !is_array($data['Disclaimer'])) {
+                $data['Disclaimer'] = [$data['Disclaimer']];
+            }
+            if (isset($data['LocalizedInstruction']) && !array_is_list($data['LocalizedInstruction'])) {
+                $data['LocalizedInstruction'] = [$data['LocalizedInstruction']];
+            }
+            if (isset($data['PromotionInformation']) && !array_is_list($data['PromotionInformation'])) {
+                $data['PromotionInformation'] = [$data['PromotionInformation']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class SearchResultsDropLocationNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force attributes to always be an array even when the API returns a single value
-        if (isset($data['PhoneNumber']) && ! is_array($data['PhoneNumber'])) {
-            $data['PhoneNumber'] = [$data['PhoneNumber']];
+            // Force attributes to always be an array even when the API returns a single value
+            if (isset($data['PhoneNumber']) && !is_array($data['PhoneNumber'])) {
+                $data['PhoneNumber'] = [$data['PhoneNumber']];
+            }
+            if (isset($data['LocationAttribute']) && !array_is_list($data['LocationAttribute'])) {
+                $data['LocationAttribute'] = [$data['LocationAttribute']];
+            }
+            if (isset($data['SpecialInstructions']) && !array_is_list($data['SpecialInstructions'])) {
+                $data['SpecialInstructions'] = [$data['SpecialInstructions']];
+            }
+            if (isset($data['LatestGroundDropOffTime']) && !is_array($data['LatestGroundDropOffTime'])) {
+                $data['LatestGroundDropOffTime'] = [$data['LatestGroundDropOffTime']];
+            }
+            if (isset($data['LatestAirDropOffTime']) && !is_array($data['LatestAirDropOffTime'])) {
+                $data['LatestAirDropOffTime'] = [$data['LatestAirDropOffTime']];
+            }
+            if (isset($data['Disclaimer']) && !is_array($data['Disclaimer'])) {
+                $data['Disclaimer'] = [$data['Disclaimer']];
+            }
+            if (isset($data['LocalizedInstruction']) && !array_is_list($data['LocalizedInstruction'])) {
+                $data['LocalizedInstruction'] = [$data['LocalizedInstruction']];
+            }
+            if (isset($data['PromotionInformation']) && !array_is_list($data['PromotionInformation'])) {
+                $data['PromotionInformation'] = [$data['PromotionInformation']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        if (isset($data['LocationAttribute']) && ! array_is_list($data['LocationAttribute'])) {
-            $data['LocationAttribute'] = [$data['LocationAttribute']];
-        }
-        if (isset($data['SpecialInstructions']) && ! array_is_list($data['SpecialInstructions'])) {
-            $data['SpecialInstructions'] = [$data['SpecialInstructions']];
-        }
-        if (isset($data['LatestGroundDropOffTime']) && ! is_array($data['LatestGroundDropOffTime'])) {
-            $data['LatestGroundDropOffTime'] = [$data['LatestGroundDropOffTime']];
-        }
-        if (isset($data['LatestAirDropOffTime']) && ! is_array($data['LatestAirDropOffTime'])) {
-            $data['LatestAirDropOffTime'] = [$data['LatestAirDropOffTime']];
-        }
-        if (isset($data['Disclaimer']) && ! is_array($data['Disclaimer'])) {
-            $data['Disclaimer'] = [$data['Disclaimer']];
-        }
-        if (isset($data['LocalizedInstruction']) && ! array_is_list($data['LocalizedInstruction'])) {
-            $data['LocalizedInstruction'] = [$data['LocalizedInstruction']];
-        }
-        if (isset($data['PromotionInformation']) && ! array_is_list($data['PromotionInformation'])) {
-            $data['PromotionInformation'] = [$data['PromotionInformation']];
-        }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/Locator/StandardHoursDayOfWeekNormalizer.php
+++ b/src/Normalizer/Locator/StandardHoursDayOfWeekNormalizer.php
@@ -3,24 +3,46 @@
 namespace ShipStream\Ups\Normalizer\Locator;
 
 use ShipStream\Ups\Api\Normalizer\StandardHoursDayOfWeekNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class StandardHoursDayOfWeekNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class StandardHoursDayOfWeekNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force DayOfWeek to always be an array even when the API returns a single value
+            if (isset($data['DayOfWeek']) && !array_is_list($data['DayOfWeek'])) {
+                $data['DayOfWeek'] = [$data['DayOfWeek']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class StandardHoursDayOfWeekNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force DayOfWeek to always be an array even when the API returns a single value
-        if (isset($data['DayOfWeek']) && ! array_is_list($data['DayOfWeek'])) {
-            $data['DayOfWeek'] = [$data['DayOfWeek']];
+            // Force DayOfWeek to always be an array even when the API returns a single value
+            if (isset($data['DayOfWeek']) && !array_is_list($data['DayOfWeek'])) {
+                $data['DayOfWeek'] = [$data['DayOfWeek']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/Paperless/DeleteResponseResponseNormalizer.php
+++ b/src/Normalizer/Paperless/DeleteResponseResponseNormalizer.php
@@ -3,24 +3,46 @@
 namespace ShipStream\Ups\Normalizer\Paperless;
 
 use ShipStream\Ups\Api\Normalizer\DeleteResponseResponseNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class DeleteResponseResponseNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class DeleteResponseResponseNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force Alert to always be an array even when the API returns a single value
+            if (isset($data['Alert']) && !array_is_list($data['Alert'])) {
+                $data['Alert'] = [$data['Alert']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class DeleteResponseResponseNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force Alert to always be an array even when the API returns a single value
-        if (isset($data['Alert']) && ! array_is_list($data['Alert'])) {
-            $data['Alert'] = [$data['Alert']];
+            // Force Alert to always be an array even when the API returns a single value
+            if (isset($data['Alert']) && !array_is_list($data['Alert'])) {
+                $data['Alert'] = [$data['Alert']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/Paperless/PushToImageRepositoryResponseResponseNormalizer.php
+++ b/src/Normalizer/Paperless/PushToImageRepositoryResponseResponseNormalizer.php
@@ -3,24 +3,46 @@
 namespace ShipStream\Ups\Normalizer\Paperless;
 
 use ShipStream\Ups\Api\Normalizer\PushToImageRepositoryResponseResponseNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class PushToImageRepositoryResponseResponseNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class PushToImageRepositoryResponseResponseNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force Alert to always be an array even when the API returns a single value
+            if (isset($data['Alert']) && !array_is_list($data['Alert'])) {
+                $data['Alert'] = [$data['Alert']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class PushToImageRepositoryResponseResponseNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force Alert to always be an array even when the API returns a single value
-        if (isset($data['Alert']) && ! array_is_list($data['Alert'])) {
-            $data['Alert'] = [$data['Alert']];
+            // Force Alert to always be an array even when the API returns a single value
+            if (isset($data['Alert']) && !array_is_list($data['Alert'])) {
+                $data['Alert'] = [$data['Alert']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/Paperless/UploadResponseResponseNormalizer.php
+++ b/src/Normalizer/Paperless/UploadResponseResponseNormalizer.php
@@ -3,24 +3,46 @@
 namespace ShipStream\Ups\Normalizer\Paperless;
 
 use ShipStream\Ups\Api\Normalizer\UploadResponseResponseNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class UploadResponseResponseNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class UploadResponseResponseNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force Alert to always be an array even when the API returns a single value
+            if (isset($data['Alert']) && !array_is_list($data['Alert'])) {
+                $data['Alert'] = [$data['Alert']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class UploadResponseResponseNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force Alert to always be an array even when the API returns a single value
-        if (isset($data['Alert']) && ! array_is_list($data['Alert'])) {
-            $data['Alert'] = [$data['Alert']];
+            // Force Alert to always be an array even when the API returns a single value
+            if (isset($data['Alert']) && !array_is_list($data['Alert'])) {
+                $data['Alert'] = [$data['Alert']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/Pickup/DropOffFacilitiesAddressNormalizer.php
+++ b/src/Normalizer/Pickup/DropOffFacilitiesAddressNormalizer.php
@@ -32,6 +32,7 @@ if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR
          * @inheritDoc
          */
         public function denormalize($data, $type, $format = null, array $context = [])
+        {
             if ($data === null || is_array($data) === false) {
                 return parent::denormalize($data, $type, $format, $context);
             }

--- a/src/Normalizer/Pickup/DropOffFacilitiesAddressNormalizer.php
+++ b/src/Normalizer/Pickup/DropOffFacilitiesAddressNormalizer.php
@@ -3,23 +3,44 @@
 namespace ShipStream\Ups\Normalizer\Pickup;
 
 use ShipStream\Ups\Api\Normalizer\DropOffFacilitiesAddressNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function is_array;
 
-class DropOffFacilitiesAddressNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class DropOffFacilitiesAddressNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force AddressLine to always be an array even when the API returns a single value
+            if (isset($data['AddressLine']) && !is_array($data['AddressLine'])) {
+                $data['AddressLine'] = [$data['AddressLine']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class DropOffFacilitiesAddressNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force AddressLine to always be an array even when the API returns a single value
-        if (isset($data['AddressLine']) && ! is_array($data['AddressLine'])) {
-            $data['AddressLine'] = [$data['AddressLine']];
+            // Force AddressLine to always be an array even when the API returns a single value
+            if (isset($data['AddressLine']) && !is_array($data['AddressLine'])) {
+                $data['AddressLine'] = [$data['AddressLine']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/Pickup/PickupGetPoliticalDivision1ListResponseNormalizer.php
+++ b/src/Normalizer/Pickup/PickupGetPoliticalDivision1ListResponseNormalizer.php
@@ -3,23 +3,45 @@
 namespace ShipStream\Ups\Normalizer\Pickup;
 
 use ShipStream\Ups\Api\Normalizer\PickupGetPoliticalDivision1ListResponseNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function is_array;
 
-class PickupGetPoliticalDivision1ListResponseNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class PickupGetPoliticalDivision1ListResponseNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force PoliticalDivision1 to always be an array even when the API returns a single value
+            if (isset($data['PoliticalDivision1']) && !is_array($data['PoliticalDivision1'])) {
+                $data['PoliticalDivision1'] = [$data['PoliticalDivision1']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class PickupGetPoliticalDivision1ListResponseNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force PoliticalDivision1 to always be an array even when the API returns a single value
-        if (isset($data['PoliticalDivision1']) && ! is_array($data['PoliticalDivision1'])) {
-            $data['PoliticalDivision1'] = [$data['PoliticalDivision1']];
+            // Force PoliticalDivision1 to always be an array even when the API returns a single value
+            if (isset($data['PoliticalDivision1']) && !is_array($data['PoliticalDivision1'])) {
+                $data['PoliticalDivision1'] = [$data['PoliticalDivision1']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/Pickup/PickupGetServiceCenterFacilitiesResponseServiceCenterLocationNormalizer.php
+++ b/src/Normalizer/Pickup/PickupGetServiceCenterFacilitiesResponseServiceCenterLocationNormalizer.php
@@ -3,24 +3,46 @@
 namespace ShipStream\Ups\Normalizer\Pickup;
 
 use ShipStream\Ups\Api\Normalizer\PickupGetServiceCenterFacilitiesResponseServiceCenterLocationNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class PickupGetServiceCenterFacilitiesResponseServiceCenterLocationNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class PickupGetServiceCenterFacilitiesResponseServiceCenterLocationNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force DropOffFacilities to always be an array even when the API returns a single value
+            if (isset($data['DropOffFacilities']) && !array_is_list($data['DropOffFacilities'])) {
+                $data['DropOffFacilities'] = [$data['DropOffFacilities']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class PickupGetServiceCenterFacilitiesResponseServiceCenterLocationNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force DropOffFacilities to always be an array even when the API returns a single value
-        if (isset($data['DropOffFacilities']) && ! array_is_list($data['DropOffFacilities'])) {
-            $data['DropOffFacilities'] = [$data['DropOffFacilities']];
+            // Force DropOffFacilities to always be an array even when the API returns a single value
+            if (isset($data['DropOffFacilities']) && !array_is_list($data['DropOffFacilities'])) {
+                $data['DropOffFacilities'] = [$data['DropOffFacilities']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/Pickup/PickupPendingStatusResponseNormalizer.php
+++ b/src/Normalizer/Pickup/PickupPendingStatusResponseNormalizer.php
@@ -3,24 +3,46 @@
 namespace ShipStream\Ups\Normalizer\Pickup;
 
 use ShipStream\Ups\Api\Normalizer\PickupPendingStatusResponseNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class PickupPendingStatusResponseNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class PickupPendingStatusResponseNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force PendingStatus to always be an array even when the API returns a single value
+            if (isset($data['PendingStatus']) && !array_is_list($data['PendingStatus'])) {
+                $data['PendingStatus'] = [$data['PendingStatus']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class PickupPendingStatusResponseNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force PendingStatus to always be an array even when the API returns a single value
-        if (isset($data['PendingStatus']) && ! array_is_list($data['PendingStatus'])) {
-            $data['PendingStatus'] = [$data['PendingStatus']];
+            // Force PendingStatus to always be an array even when the API returns a single value
+            if (isset($data['PendingStatus']) && !array_is_list($data['PendingStatus'])) {
+                $data['PendingStatus'] = [$data['PendingStatus']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/Pickup/PickupRateResponseRateResultNormalizer.php
+++ b/src/Normalizer/Pickup/PickupRateResponseRateResultNormalizer.php
@@ -3,27 +3,52 @@
 namespace ShipStream\Ups\Normalizer\Pickup;
 
 use ShipStream\Ups\Api\Normalizer\PickupRateResponseRateResultNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class PickupRateResponseRateResultNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class PickupRateResponseRateResultNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force fields to always be an array even when the API returns a single value
+            if (isset($data['ChargeDetail']) && !array_is_list($data['ChargeDetail'])) {
+                $data['ChargeDetail'] = [$data['ChargeDetail']];
+            }
+            if (isset($data['TaxCharges']) && !array_is_list($data['TaxCharges'])) {
+                $data['TaxCharges'] = [$data['TaxCharges']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class PickupRateResponseRateResultNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force fields to always be an array even when the API returns a single value
-        if (isset($data['ChargeDetail']) && ! array_is_list($data['ChargeDetail'])) {
-            $data['ChargeDetail'] = [$data['ChargeDetail']];
+            // Force fields to always be an array even when the API returns a single value
+            if (isset($data['ChargeDetail']) && !array_is_list($data['ChargeDetail'])) {
+                $data['ChargeDetail'] = [$data['ChargeDetail']];
+            }
+            if (isset($data['TaxCharges']) && !array_is_list($data['TaxCharges'])) {
+                $data['TaxCharges'] = [$data['TaxCharges']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        if (isset($data['TaxCharges']) && ! array_is_list($data['TaxCharges'])) {
-            $data['TaxCharges'] = [$data['TaxCharges']];
-        }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/Pickup/ServiceCenterLocationDropOffFacilitiesNormalizer.php
+++ b/src/Normalizer/Pickup/ServiceCenterLocationDropOffFacilitiesNormalizer.php
@@ -3,24 +3,46 @@
 namespace ShipStream\Ups\Normalizer\Pickup;
 
 use ShipStream\Ups\Api\Normalizer\ServiceCenterLocationDropOffFacilitiesNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class ServiceCenterLocationDropOffFacilitiesNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class ServiceCenterLocationDropOffFacilitiesNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force LocalizedInstruction to always be an array even when the API returns a single value
+            if (isset($data['LocalizedInstruction']) && !array_is_list($data['LocalizedInstruction'])) {
+                $data['LocalizedInstruction'] = [$data['LocalizedInstruction']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class ServiceCenterLocationDropOffFacilitiesNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force LocalizedInstruction to always be an array even when the API returns a single value
-        if (isset($data['LocalizedInstruction']) && ! array_is_list($data['LocalizedInstruction'])) {
-            $data['LocalizedInstruction'] = [$data['LocalizedInstruction']];
+            // Force LocalizedInstruction to always be an array even when the API returns a single value
+            if (isset($data['LocalizedInstruction']) && !array_is_list($data['LocalizedInstruction'])) {
+                $data['LocalizedInstruction'] = [$data['LocalizedInstruction']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/PreNotification/PreNotificationResponseResponseNormalizer.php
+++ b/src/Normalizer/PreNotification/PreNotificationResponseResponseNormalizer.php
@@ -3,24 +3,46 @@
 namespace ShipStream\Ups\Normalizer\PreNotification;
 
 use ShipStream\Ups\Api\Normalizer\PreNotificationResponseResponseNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class PreNotificationResponseResponseNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class PreNotificationResponseResponseNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force Alert to always be an array even when the API returns a single value
+            if (isset($data['Alert']) && !array_is_list($data['Alert'])) {
+                $data['Alert'] = [$data['Alert']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class PreNotificationResponseResponseNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force Alert to always be an array even when the API returns a single value
-        if (isset($data['Alert']) && ! array_is_list($data['Alert'])) {
-            $data['Alert'] = [$data['Alert']];
+            // Force Alert to always be an array even when the API returns a single value
+            if (isset($data['Alert']) && !array_is_list($data['Alert'])) {
+                $data['Alert'] = [$data['Alert']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/QuantumView/DeliveryLocationAddressArtifactFormatNormalizer.php
+++ b/src/Normalizer/QuantumView/DeliveryLocationAddressArtifactFormatNormalizer.php
@@ -3,24 +3,46 @@
 namespace ShipStream\Ups\Normalizer\QuantumView;
 
 use ShipStream\Ups\Api\Normalizer\DeliveryLocationAddressArtifactFormatNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class DeliveryLocationAddressArtifactFormatNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class DeliveryLocationAddressArtifactFormatNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force AddressExtendedInformation to always be an array even when the API returns a single value
+            if (isset($data['AddressExtendedInformation']) && !array_is_list($data['AddressExtendedInformation'])) {
+                $data['AddressExtendedInformation'] = [$data['AddressExtendedInformation']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class DeliveryLocationAddressArtifactFormatNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force AddressExtendedInformation to always be an array even when the API returns a single value
-        if (isset($data['AddressExtendedInformation']) && ! array_is_list($data['AddressExtendedInformation'])) {
-            $data['AddressExtendedInformation'] = [$data['AddressExtendedInformation']];
+            // Force AddressExtendedInformation to always be an array even when the API returns a single value
+            if (isset($data['AddressExtendedInformation']) && !array_is_list($data['AddressExtendedInformation'])) {
+                $data['AddressExtendedInformation'] = [$data['AddressExtendedInformation']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/QuantumView/ExceptionUpdatedAddressNormalizer.php
+++ b/src/Normalizer/QuantumView/ExceptionUpdatedAddressNormalizer.php
@@ -28,21 +28,21 @@ class ExceptionUpdatedAddressNormalizer extends BaseNormalizer
 }
 } else {
     class ExceptionUpdatedAddressNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize($data, $type, $format = null, array $context = [])
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force AddressExtendedInformation to always be an array even when the API returns a single value
+            if (isset($data['AddressExtendedInformation']) && ! array_is_list($data['AddressExtendedInformation'])) {
+                $data['AddressExtendedInformation'] = [$data['AddressExtendedInformation']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
-
-        // Force AddressExtendedInformation to always be an array even when the API returns a single value
-        if (isset($data['AddressExtendedInformation']) && ! array_is_list($data['AddressExtendedInformation'])) {
-            $data['AddressExtendedInformation'] = [$data['AddressExtendedInformation']];
-        }
-        return parent::denormalize($data, $type, $format, $context);
     }
-}
 }

--- a/src/Normalizer/QuantumView/ExceptionUpdatedAddressNormalizer.php
+++ b/src/Normalizer/QuantumView/ExceptionUpdatedAddressNormalizer.php
@@ -3,9 +3,11 @@
 namespace ShipStream\Ups\Normalizer\QuantumView;
 
 use ShipStream\Ups\Api\Normalizer\ExceptionUpdatedAddressNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
 class ExceptionUpdatedAddressNormalizer extends BaseNormalizer
 {
     /**
@@ -23,4 +25,24 @@ class ExceptionUpdatedAddressNormalizer extends BaseNormalizer
         }
         return parent::denormalize($data, $type, $format, $context);
     }
+}
+} else {
+    class ExceptionUpdatedAddressNormalizer extends BaseNormalizer
+{
+    /**
+     * @inheritDoc
+     */
+    public function denormalize($data, $type, $format = null, array $context = [])
+    {
+        if ($data === null || is_array($data) === false) {
+            return parent::denormalize($data, $type, $format, $context);
+        }
+
+        // Force AddressExtendedInformation to always be an array even when the API returns a single value
+        if (isset($data['AddressExtendedInformation']) && ! array_is_list($data['AddressExtendedInformation'])) {
+            $data['AddressExtendedInformation'] = [$data['AddressExtendedInformation']];
+        }
+        return parent::denormalize($data, $type, $format, $context);
+    }
+}
 }

--- a/src/Normalizer/QuantumView/ManifestPackageNormalizer.php
+++ b/src/Normalizer/QuantumView/ManifestPackageNormalizer.php
@@ -3,24 +3,46 @@
 namespace ShipStream\Ups\Normalizer\QuantumView;
 
 use ShipStream\Ups\Api\Normalizer\ManifestPackageNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class ManifestPackageNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class ManifestPackageNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force Activity to always be an array even when the API returns a single value
+            if (isset($data['Activity']) && !array_is_list($data['Activity'])) {
+                $data['Activity'] = [$data['Activity']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class ManifestPackageNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force Activity to always be an array even when the API returns a single value
-        if (isset($data['Activity']) && ! array_is_list($data['Activity'])) {
-            $data['Activity'] = [$data['Activity']];
+            // Force Activity to always be an array even when the API returns a single value
+            if (isset($data['Activity']) && !array_is_list($data['Activity'])) {
+                $data['Activity'] = [$data['Activity']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/QuantumView/QuantumViewEventsSubscriptionEventsNormalizer.php
+++ b/src/Normalizer/QuantumView/QuantumViewEventsSubscriptionEventsNormalizer.php
@@ -3,24 +3,46 @@
 namespace ShipStream\Ups\Normalizer\QuantumView;
 
 use ShipStream\Ups\Api\Normalizer\QuantumViewEventsSubscriptionEventsNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class QuantumViewEventsSubscriptionEventsNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class QuantumViewEventsSubscriptionEventsNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force SubscriptionFile to always be an array even when the API returns a single value
+            if (isset($data['SubscriptionFile']) && !array_is_list($data['SubscriptionFile'])) {
+                $data['SubscriptionFile'] = [$data['SubscriptionFile']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class QuantumViewEventsSubscriptionEventsNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force SubscriptionFile to always be an array even when the API returns a single value
-        if (isset($data['SubscriptionFile']) && ! array_is_list($data['SubscriptionFile'])) {
-            $data['SubscriptionFile'] = [$data['SubscriptionFile']];
+            // Force SubscriptionFile to always be an array even when the API returns a single value
+            if (isset($data['SubscriptionFile']) && !array_is_list($data['SubscriptionFile'])) {
+                $data['SubscriptionFile'] = [$data['SubscriptionFile']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/QuantumView/QuantumViewResponseQuantumViewEventsNormalizer.php
+++ b/src/Normalizer/QuantumView/QuantumViewResponseQuantumViewEventsNormalizer.php
@@ -3,24 +3,46 @@
 namespace ShipStream\Ups\Normalizer\QuantumView;
 
 use ShipStream\Ups\Api\Normalizer\QuantumViewResponseQuantumViewEventsNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class QuantumViewResponseQuantumViewEventsNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class QuantumViewResponseQuantumViewEventsNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force SubscriptionFile to always be an array even when the API returns a single value
+            if (isset($data['SubscriptionEvents']) && !array_is_list($data['SubscriptionEvents'])) {
+                $data['SubscriptionEvents'] = [$data['SubscriptionEvents']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class QuantumViewResponseQuantumViewEventsNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force SubscriptionFile to always be an array even when the API returns a single value
-        if (isset($data['SubscriptionEvents']) && ! array_is_list($data['SubscriptionEvents'])) {
-            $data['SubscriptionEvents'] = [$data['SubscriptionEvents']];
+            // Force SubscriptionFile to always be an array even when the API returns a single value
+            if (isset($data['SubscriptionEvents']) && !array_is_list($data['SubscriptionEvents'])) {
+                $data['SubscriptionEvents'] = [$data['SubscriptionEvents']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/QuantumView/QuantumViewResponseResponseNormalizer.php
+++ b/src/Normalizer/QuantumView/QuantumViewResponseResponseNormalizer.php
@@ -3,24 +3,46 @@
 namespace ShipStream\Ups\Normalizer\QuantumView;
 
 use ShipStream\Ups\Api\Normalizer\QuantumViewResponseResponseNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class QuantumViewResponseResponseNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class QuantumViewResponseResponseNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force Error to always be an array even when the API returns a single value
+            if (isset($data['Error']) && !array_is_list($data['Error'])) {
+                $data['Error'] = [$data['Error']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class QuantumViewResponseResponseNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force Error to always be an array even when the API returns a single value
-        if (isset($data['Error']) && ! array_is_list($data['Error'])) {
-            $data['Error'] = [$data['Error']];
+            // Force Error to always be an array even when the API returns a single value
+            if (isset($data['Error']) && !array_is_list($data['Error'])) {
+                $data['Error'] = [$data['Error']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/QuantumView/SubscriptionEventsSubscriptionFileNormalizer.php
+++ b/src/Normalizer/QuantumView/SubscriptionEventsSubscriptionFileNormalizer.php
@@ -3,36 +3,70 @@
 namespace ShipStream\Ups\Normalizer\QuantumView;
 
 use ShipStream\Ups\Api\Normalizer\SubscriptionEventsSubscriptionFileNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class SubscriptionEventsSubscriptionFileNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class SubscriptionEventsSubscriptionFileNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force Manifest to always be an array even when the API returns a single value
+            if (isset($data['Manifest']) && !array_is_list($data['Manifest'])) {
+                $data['Manifest'] = [$data['Manifest']];
+            }
+            if (isset($data['Origin']) && !array_is_list($data['Origin'])) {
+                $data['Origin'] = [$data['Origin']];
+            }
+            if (isset($data['Exception']) && !array_is_list($data['Exception'])) {
+                $data['Exception'] = [$data['Exception']];
+            }
+            if (isset($data['Delivery']) && !array_is_list($data['Delivery'])) {
+                $data['Delivery'] = [$data['Delivery']];
+            }
+            if (isset($data['Generic']) && !array_is_list($data['Generic'])) {
+                $data['Generic'] = [$data['Generic']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class SubscriptionEventsSubscriptionFileNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force Manifest to always be an array even when the API returns a single value
-        if (isset($data['Manifest']) && ! array_is_list($data['Manifest'])) {
-            $data['Manifest'] = [$data['Manifest']];
+            // Force Manifest to always be an array even when the API returns a single value
+            if (isset($data['Manifest']) && !array_is_list($data['Manifest'])) {
+                $data['Manifest'] = [$data['Manifest']];
+            }
+            if (isset($data['Origin']) && !array_is_list($data['Origin'])) {
+                $data['Origin'] = [$data['Origin']];
+            }
+            if (isset($data['Exception']) && !array_is_list($data['Exception'])) {
+                $data['Exception'] = [$data['Exception']];
+            }
+            if (isset($data['Delivery']) && !array_is_list($data['Delivery'])) {
+                $data['Delivery'] = [$data['Delivery']];
+            }
+            if (isset($data['Generic']) && !array_is_list($data['Generic'])) {
+                $data['Generic'] = [$data['Generic']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        if (isset($data['Origin']) && ! array_is_list($data['Origin'])) {
-            $data['Origin'] = [$data['Origin']];
-        }
-        if (isset($data['Exception']) && ! array_is_list($data['Exception'])) {
-            $data['Exception'] = [$data['Exception']];
-        }
-        if (isset($data['Delivery']) && ! array_is_list($data['Delivery'])) {
-            $data['Delivery'] = [$data['Delivery']];
-        }
-        if (isset($data['Generic']) && ! array_is_list($data['Generic'])) {
-            $data['Generic'] = [$data['Generic']];
-        }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/QuantumView/SubscriptionFileDeliveryNormalizer.php
+++ b/src/Normalizer/QuantumView/SubscriptionFileDeliveryNormalizer.php
@@ -3,27 +3,52 @@
 namespace ShipStream\Ups\Normalizer\QuantumView;
 
 use ShipStream\Ups\Api\Normalizer\SubscriptionFileDeliveryNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class SubscriptionFileDeliveryNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class SubscriptionFileDeliveryNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force fields to always be an array even when the API returns a single value
+            if (isset($data['PackageReferenceNumber']) && !array_is_list($data['PackageReferenceNumber'])) {
+                $data['PackageReferenceNumber'] = [$data['PackageReferenceNumber']];
+            }
+            if (isset($data['ShipmentReferenceNumber']) && !array_is_list($data['ShipmentReferenceNumber'])) {
+                $data['ShipmentReferenceNumber'] = [$data['ShipmentReferenceNumber']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class SubscriptionFileDeliveryNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force fields to always be an array even when the API returns a single value
-        if (isset($data['PackageReferenceNumber']) && ! array_is_list($data['PackageReferenceNumber'])) {
-            $data['PackageReferenceNumber'] = [$data['PackageReferenceNumber']];
+            // Force fields to always be an array even when the API returns a single value
+            if (isset($data['PackageReferenceNumber']) && !array_is_list($data['PackageReferenceNumber'])) {
+                $data['PackageReferenceNumber'] = [$data['PackageReferenceNumber']];
+            }
+            if (isset($data['ShipmentReferenceNumber']) && !array_is_list($data['ShipmentReferenceNumber'])) {
+                $data['ShipmentReferenceNumber'] = [$data['ShipmentReferenceNumber']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        if (isset($data['ShipmentReferenceNumber']) && ! array_is_list($data['ShipmentReferenceNumber'])) {
-            $data['ShipmentReferenceNumber'] = [$data['ShipmentReferenceNumber']];
-        }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/QuantumView/SubscriptionFileExceptionNormalizer.php
+++ b/src/Normalizer/QuantumView/SubscriptionFileExceptionNormalizer.php
@@ -36,6 +36,7 @@ if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR
          * @inheritDoc
          */
         public function denormalize($data, $type, $format = null, array $context = [])
+        {
             if ($data === null || is_array($data) === false) {
                 return parent::denormalize($data, $type, $format, $context);
             }

--- a/src/Normalizer/QuantumView/SubscriptionFileExceptionNormalizer.php
+++ b/src/Normalizer/QuantumView/SubscriptionFileExceptionNormalizer.php
@@ -3,27 +3,51 @@
 namespace ShipStream\Ups\Normalizer\QuantumView;
 
 use ShipStream\Ups\Api\Normalizer\SubscriptionFileExceptionNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class SubscriptionFileExceptionNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class SubscriptionFileExceptionNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force fields to always be an array even when the API returns a single value
+            if (isset($data['PackageReferenceNumber']) && !array_is_list($data['PackageReferenceNumber'])) {
+                $data['PackageReferenceNumber'] = [$data['PackageReferenceNumber']];
+            }
+            if (isset($data['ShipmentReferenceNumber']) && !array_is_list($data['ShipmentReferenceNumber'])) {
+                $data['ShipmentReferenceNumber'] = [$data['ShipmentReferenceNumber']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class SubscriptionFileExceptionNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force fields to always be an array even when the API returns a single value
-        if (isset($data['PackageReferenceNumber']) && ! array_is_list($data['PackageReferenceNumber'])) {
-            $data['PackageReferenceNumber'] = [$data['PackageReferenceNumber']];
+            // Force fields to always be an array even when the API returns a single value
+            if (isset($data['PackageReferenceNumber']) && !array_is_list($data['PackageReferenceNumber'])) {
+                $data['PackageReferenceNumber'] = [$data['PackageReferenceNumber']];
+            }
+            if (isset($data['ShipmentReferenceNumber']) && !array_is_list($data['ShipmentReferenceNumber'])) {
+                $data['ShipmentReferenceNumber'] = [$data['ShipmentReferenceNumber']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        if (isset($data['ShipmentReferenceNumber']) && ! array_is_list($data['ShipmentReferenceNumber'])) {
-            $data['ShipmentReferenceNumber'] = [$data['ShipmentReferenceNumber']];
-        }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/QuantumView/SubscriptionFileGenericNormalizer.php
+++ b/src/Normalizer/QuantumView/SubscriptionFileGenericNormalizer.php
@@ -3,27 +3,52 @@
 namespace ShipStream\Ups\Normalizer\QuantumView;
 
 use ShipStream\Ups\Api\Normalizer\SubscriptionFileGenericNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class SubscriptionFileGenericNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class SubscriptionFileGenericNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force fields to always be an array even when the API returns a single value
+            if (isset($data['ShipmentReferenceNumber']) && !array_is_list($data['ShipmentReferenceNumber'])) {
+                $data['ShipmentReferenceNumber'] = [$data['ShipmentReferenceNumber']];
+            }
+            if (isset($data['PackageReferenceNumber']) && !array_is_list($data['PackageReferenceNumber'])) {
+                $data['PackageReferenceNumber'] = [$data['PackageReferenceNumber']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class SubscriptionFileGenericNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force fields to always be an array even when the API returns a single value
-        if (isset($data['ShipmentReferenceNumber']) && ! array_is_list($data['ShipmentReferenceNumber'])) {
-            $data['ShipmentReferenceNumber'] = [$data['ShipmentReferenceNumber']];
+            // Force fields to always be an array even when the API returns a single value
+            if (isset($data['ShipmentReferenceNumber']) && !array_is_list($data['ShipmentReferenceNumber'])) {
+                $data['ShipmentReferenceNumber'] = [$data['ShipmentReferenceNumber']];
+            }
+            if (isset($data['PackageReferenceNumber']) && !array_is_list($data['PackageReferenceNumber'])) {
+                $data['PackageReferenceNumber'] = [$data['PackageReferenceNumber']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        if (isset($data['PackageReferenceNumber']) && ! array_is_list($data['PackageReferenceNumber'])) {
-            $data['PackageReferenceNumber'] = [$data['PackageReferenceNumber']];
-        }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/QuantumView/SubscriptionFileManifestNormalizer.php
+++ b/src/Normalizer/QuantumView/SubscriptionFileManifestNormalizer.php
@@ -8,27 +8,47 @@ use function array_is_list;
 use function is_array;
 
 if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
-class SubscriptionFileManifestNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = [])
+    class SubscriptionFileManifestNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force fields to always be an array even when the API returns a single value
+            if (isset($data['ReferenceNumber']) && ! array_is_list($data['ReferenceNumber'])) {
+                $data['ReferenceNumber'] = [$data['ReferenceNumber']];
+            }
+            if (isset($data['Package']) && ! array_is_list($data['Package'])) {
+                $data['Package'] = [$data['Package']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
-
-        // Force fields to always be an array even when the API returns a single value
-        if (isset($data['ReferenceNumber']) && ! array_is_list($data['ReferenceNumber'])) {
-            $data['ReferenceNumber'] = [$data['ReferenceNumber']];
-        }
-        if (isset($data['Package']) && ! array_is_list($data['Package'])) {
-            $data['Package'] = [$data['Package']];
-        }
-        return parent::denormalize($data, $type, $format, $context);
     }
-}
 } else {
-    
+    class SubscriptionFileManifestNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force fields to always be an array even when the API returns a single value
+            if (isset($data['ReferenceNumber']) && ! array_is_list($data['ReferenceNumber'])) {
+                $data['ReferenceNumber'] = [$data['ReferenceNumber']];
+            }
+            if (isset($data['Package']) && ! array_is_list($data['Package'])) {
+                $data['Package'] = [$data['Package']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
+        }
+    }
 }

--- a/src/Normalizer/QuantumView/SubscriptionFileManifestNormalizer.php
+++ b/src/Normalizer/QuantumView/SubscriptionFileManifestNormalizer.php
@@ -3,15 +3,17 @@
 namespace ShipStream\Ups\Normalizer\QuantumView;
 
 use ShipStream\Ups\Api\Normalizer\SubscriptionFileManifestNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
 class SubscriptionFileManifestNormalizer extends BaseNormalizer
 {
     /**
      * @inheritDoc
      */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = [])
     {
         if ($data === null || is_array($data) === false) {
             return parent::denormalize($data, $type, $format, $context);
@@ -26,4 +28,7 @@ class SubscriptionFileManifestNormalizer extends BaseNormalizer
         }
         return parent::denormalize($data, $type, $format, $context);
     }
+}
+} else {
+    
 }

--- a/src/Normalizer/QuantumView/SubscriptionFileOriginNormalizer.php
+++ b/src/Normalizer/QuantumView/SubscriptionFileOriginNormalizer.php
@@ -3,27 +3,52 @@
 namespace ShipStream\Ups\Normalizer\QuantumView;
 
 use ShipStream\Ups\Api\Normalizer\SubscriptionFileOriginNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class SubscriptionFileOriginNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class SubscriptionFileOriginNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force fields to always be an array even when the API returns a single value
+            if (isset($data['PackageReferenceNumber']) && !array_is_list($data['PackageReferenceNumber'])) {
+                $data['PackageReferenceNumber'] = [$data['PackageReferenceNumber']];
+            }
+            if (isset($data['ShipmentReferenceNumber']) && !array_is_list($data['ShipmentReferenceNumber'])) {
+                $data['ShipmentReferenceNumber'] = [$data['ShipmentReferenceNumber']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class SubscriptionFileOriginNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force fields to always be an array even when the API returns a single value
-        if (isset($data['PackageReferenceNumber']) && ! array_is_list($data['PackageReferenceNumber'])) {
-            $data['PackageReferenceNumber'] = [$data['PackageReferenceNumber']];
+            // Force fields to always be an array even when the API returns a single value
+            if (isset($data['PackageReferenceNumber']) && !array_is_list($data['PackageReferenceNumber'])) {
+                $data['PackageReferenceNumber'] = [$data['PackageReferenceNumber']];
+            }
+            if (isset($data['ShipmentReferenceNumber']) && !array_is_list($data['ShipmentReferenceNumber'])) {
+                $data['ShipmentReferenceNumber'] = [$data['ShipmentReferenceNumber']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        if (isset($data['ShipmentReferenceNumber']) && ! array_is_list($data['ShipmentReferenceNumber'])) {
-            $data['ShipmentReferenceNumber'] = [$data['ShipmentReferenceNumber']];
-        }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/Rating/AlertDetailElementLevelInformationNormalizer.php
+++ b/src/Normalizer/Rating/AlertDetailElementLevelInformationNormalizer.php
@@ -3,24 +3,46 @@
 namespace ShipStream\Ups\Normalizer\Rating;
 
 use ShipStream\Ups\Api\Normalizer\AlertDetailElementLevelInformationNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class AlertDetailElementLevelInformationNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class AlertDetailElementLevelInformationNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force ElementLevelInformation to always be an array even when the API returns a single value
+            if (isset($data['ElementLevelInformation']) && !array_is_list($data['ElementLevelInformation'])) {
+                $data['ElementLevelInformation'] = [$data['ElementLevelInformation']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class AlertDetailElementLevelInformationNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force ElementLevelInformation to always be an array even when the API returns a single value
-        if (isset($data['ElementLevelInformation']) && ! array_is_list($data['ElementLevelInformation'])) {
-            $data['ElementLevelInformation'] = [$data['ElementLevelInformation']];
+            // Force ElementLevelInformation to always be an array even when the API returns a single value
+            if (isset($data['ElementLevelInformation']) && !array_is_list($data['ElementLevelInformation'])) {
+                $data['ElementLevelInformation'] = [$data['ElementLevelInformation']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/Rating/RateResponseNormalizer.php
+++ b/src/Normalizer/Rating/RateResponseNormalizer.php
@@ -3,24 +3,46 @@
 namespace ShipStream\Ups\Normalizer\Rating;
 
 use ShipStream\Ups\Api\Normalizer\RateResponseNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class RateResponseNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class RateResponseNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force RatedShipment to always be an array even when the API returns a single value
+            if (isset($data['RatedShipment']) && !array_is_list($data['RatedShipment'])) {
+                $data['RatedShipment'] = [$data['RatedShipment']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class RateResponseNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force RatedShipment to always be an array even when the API returns a single value
-        if (isset($data['RatedShipment']) && ! array_is_list($data['RatedShipment'])) {
-            $data['RatedShipment'] = [$data['RatedShipment']];
+            // Force RatedShipment to always be an array even when the API returns a single value
+            if (isset($data['RatedShipment']) && !array_is_list($data['RatedShipment'])) {
+                $data['RatedShipment'] = [$data['RatedShipment']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/Rating/RateResponseRatedShipmentNormalizer.php
+++ b/src/Normalizer/Rating/RateResponseRatedShipmentNormalizer.php
@@ -3,39 +3,76 @@
 namespace ShipStream\Ups\Normalizer\Rating;
 
 use ShipStream\Ups\Api\Normalizer\RateResponseRatedShipmentNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class RateResponseRatedShipmentNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class RateResponseRatedShipmentNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force fields to always be an array even when the API returns a single value
+            if (isset($data['Disclaimer']) && !array_is_list($data['Disclaimer'])) {
+                $data['Disclaimer'] = [$data['Disclaimer']];
+            }
+            if (isset($data['RatedShipmentAlert']) && !array_is_list($data['RatedShipmentAlert'])) {
+                $data['RatedShipmentAlert'] = [$data['RatedShipmentAlert']];
+            }
+            if (isset($data['ItemizedCharges']) && !array_is_list($data['ItemizedCharges'])) {
+                $data['ItemizedCharges'] = [$data['ItemizedCharges']];
+            }
+            if (isset($data['TaxCharges']) && !array_is_list($data['TaxCharges'])) {
+                $data['TaxCharges'] = [$data['TaxCharges']];
+            }
+            if (isset($data['RatedPackage']) && !array_is_list($data['RatedPackage'])) {
+                $data['RatedPackage'] = [$data['RatedPackage']];
+            }
+            if (isset($data['HandlingUnits']) && !array_is_list($data['HandlingUnits'])) {
+                $data['HandlingUnits'] = [$data['HandlingUnits']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class RateResponseRatedShipmentNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force fields to always be an array even when the API returns a single value
-        if (isset($data['Disclaimer']) && ! array_is_list($data['Disclaimer'])) {
-            $data['Disclaimer'] = [$data['Disclaimer']];
+            // Force fields to always be an array even when the API returns a single value
+            if (isset($data['Disclaimer']) && !array_is_list($data['Disclaimer'])) {
+                $data['Disclaimer'] = [$data['Disclaimer']];
+            }
+            if (isset($data['RatedShipmentAlert']) && !array_is_list($data['RatedShipmentAlert'])) {
+                $data['RatedShipmentAlert'] = [$data['RatedShipmentAlert']];
+            }
+            if (isset($data['ItemizedCharges']) && !array_is_list($data['ItemizedCharges'])) {
+                $data['ItemizedCharges'] = [$data['ItemizedCharges']];
+            }
+            if (isset($data['TaxCharges']) && !array_is_list($data['TaxCharges'])) {
+                $data['TaxCharges'] = [$data['TaxCharges']];
+            }
+            if (isset($data['RatedPackage']) && !array_is_list($data['RatedPackage'])) {
+                $data['RatedPackage'] = [$data['RatedPackage']];
+            }
+            if (isset($data['HandlingUnits']) && !array_is_list($data['HandlingUnits'])) {
+                $data['HandlingUnits'] = [$data['HandlingUnits']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        if (isset($data['RatedShipmentAlert']) && ! array_is_list($data['RatedShipmentAlert'])) {
-            $data['RatedShipmentAlert'] = [$data['RatedShipmentAlert']];
-        }
-        if (isset($data['ItemizedCharges']) && ! array_is_list($data['ItemizedCharges'])) {
-            $data['ItemizedCharges'] = [$data['ItemizedCharges']];
-        }
-        if (isset($data['TaxCharges']) && ! array_is_list($data['TaxCharges'])) {
-            $data['TaxCharges'] = [$data['TaxCharges']];
-        }
-        if (isset($data['RatedPackage']) && ! array_is_list($data['RatedPackage'])) {
-            $data['RatedPackage'] = [$data['RatedPackage']];
-        }
-        if (isset($data['HandlingUnits']) && ! array_is_list($data['HandlingUnits'])) {
-            $data['HandlingUnits'] = [$data['HandlingUnits']];
-        }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/Rating/RateResponseResponseNormalizer.php
+++ b/src/Normalizer/Rating/RateResponseResponseNormalizer.php
@@ -8,47 +8,47 @@ use function array_is_list;
 use function is_array;
 
 if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
-class RateResponseResponseNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    class RateResponseResponseNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force fields to always be an array even when the API returns a single value
+            if (isset($data['Alert']) && ! array_is_list($data['Alert'])) {
+                $data['Alert'] = [$data['Alert']];
+            }
+            if (isset($data['AlertDetail']) && ! array_is_list($data['AlertDetail'])) {
+                $data['AlertDetail'] = [$data['AlertDetail']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
-
-        // Force fields to always be an array even when the API returns a single value
-        if (isset($data['Alert']) && ! array_is_list($data['Alert'])) {
-            $data['Alert'] = [$data['Alert']];
-        }
-        if (isset($data['AlertDetail']) && ! array_is_list($data['AlertDetail'])) {
-            $data['AlertDetail'] = [$data['AlertDetail']];
-        }
-        return parent::denormalize($data, $type, $format, $context);
     }
-}
 } else {
     class RateResponseResponseNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize($data, $type, $format = null, array $context = [])
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force fields to always be an array even when the API returns a single value
+            if (isset($data['Alert']) && ! array_is_list($data['Alert'])) {
+                $data['Alert'] = [$data['Alert']];
+            }
+            if (isset($data['AlertDetail']) && ! array_is_list($data['AlertDetail'])) {
+                $data['AlertDetail'] = [$data['AlertDetail']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
-
-        // Force fields to always be an array even when the API returns a single value
-        if (isset($data['Alert']) && ! array_is_list($data['Alert'])) {
-            $data['Alert'] = [$data['Alert']];
-        }
-        if (isset($data['AlertDetail']) && ! array_is_list($data['AlertDetail'])) {
-            $data['AlertDetail'] = [$data['AlertDetail']];
-        }
-        return parent::denormalize($data, $type, $format, $context);
     }
-}
 }

--- a/src/Normalizer/Rating/RateResponseResponseNormalizer.php
+++ b/src/Normalizer/Rating/RateResponseResponseNormalizer.php
@@ -3,9 +3,11 @@
 namespace ShipStream\Ups\Normalizer\Rating;
 
 use ShipStream\Ups\Api\Normalizer\RateResponseResponseNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
 class RateResponseResponseNormalizer extends BaseNormalizer
 {
     /**
@@ -26,4 +28,27 @@ class RateResponseResponseNormalizer extends BaseNormalizer
         }
         return parent::denormalize($data, $type, $format, $context);
     }
+}
+} else {
+    class RateResponseResponseNormalizer extends BaseNormalizer
+{
+    /**
+     * @inheritDoc
+     */
+    public function denormalize($data, $type, $format = null, array $context = [])
+    {
+        if ($data === null || is_array($data) === false) {
+            return parent::denormalize($data, $type, $format, $context);
+        }
+
+        // Force fields to always be an array even when the API returns a single value
+        if (isset($data['Alert']) && ! array_is_list($data['Alert'])) {
+            $data['Alert'] = [$data['Alert']];
+        }
+        if (isset($data['AlertDetail']) && ! array_is_list($data['AlertDetail'])) {
+            $data['AlertDetail'] = [$data['AlertDetail']];
+        }
+        return parent::denormalize($data, $type, $format, $context);
+    }
+}
 }

--- a/src/Normalizer/Rating/RatedPackageNegotiatedChargesNormalizer.php
+++ b/src/Normalizer/Rating/RatedPackageNegotiatedChargesNormalizer.php
@@ -3,24 +3,46 @@
 namespace ShipStream\Ups\Normalizer\Rating;
 
 use ShipStream\Ups\Api\Normalizer\RatedPackageNegotiatedChargesNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class RatedPackageNegotiatedChargesNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class RatedPackageNegotiatedChargesNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force ItemizedCharges to always be an array even when the API returns a single value
+            if (isset($data['ItemizedCharges']) && !array_is_list($data['ItemizedCharges'])) {
+                $data['ItemizedCharges'] = [$data['ItemizedCharges']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class RatedPackageNegotiatedChargesNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force ItemizedCharges to always be an array even when the API returns a single value
-        if (isset($data['ItemizedCharges']) && ! array_is_list($data['ItemizedCharges'])) {
-            $data['ItemizedCharges'] = [$data['ItemizedCharges']];
+            // Force ItemizedCharges to always be an array even when the API returns a single value
+            if (isset($data['ItemizedCharges']) && !array_is_list($data['ItemizedCharges'])) {
+                $data['ItemizedCharges'] = [$data['ItemizedCharges']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/Rating/RatedShipmentNegotiatedRateChargesNormalizer.php
+++ b/src/Normalizer/Rating/RatedShipmentNegotiatedRateChargesNormalizer.php
@@ -3,27 +3,52 @@
 namespace ShipStream\Ups\Normalizer\Rating;
 
 use ShipStream\Ups\Api\Normalizer\RatedShipmentNegotiatedRateChargesNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class RatedShipmentNegotiatedRateChargesNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class RatedShipmentNegotiatedRateChargesNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force fields to always be an array even when the API returns a single value
+            if (isset($data['ItemizedCharges']) && !array_is_list($data['ItemizedCharges'])) {
+                $data['ItemizedCharges'] = [$data['ItemizedCharges']];
+            }
+            if (isset($data['TaxCharges']) && !array_is_list($data['TaxCharges'])) {
+                $data['TaxCharges'] = [$data['TaxCharges']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class RatedShipmentNegotiatedRateChargesNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force fields to always be an array even when the API returns a single value
-        if (isset($data['ItemizedCharges']) && ! array_is_list($data['ItemizedCharges'])) {
-            $data['ItemizedCharges'] = [$data['ItemizedCharges']];
+            // Force fields to always be an array even when the API returns a single value
+            if (isset($data['ItemizedCharges']) && !array_is_list($data['ItemizedCharges'])) {
+                $data['ItemizedCharges'] = [$data['ItemizedCharges']];
+            }
+            if (isset($data['TaxCharges']) && !array_is_list($data['TaxCharges'])) {
+                $data['TaxCharges'] = [$data['TaxCharges']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        if (isset($data['TaxCharges']) && ! array_is_list($data['TaxCharges'])) {
-            $data['TaxCharges'] = [$data['TaxCharges']];
-        }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/Rating/RatedShipmentRatedPackageNormalizer.php
+++ b/src/Normalizer/Rating/RatedShipmentRatedPackageNormalizer.php
@@ -3,30 +3,58 @@
 namespace ShipStream\Ups\Normalizer\Rating;
 
 use ShipStream\Ups\Api\Normalizer\RatedShipmentRatedPackageNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class RatedShipmentRatedPackageNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class RatedShipmentRatedPackageNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force fields to always be an array even when the API returns a single value
+            if (isset($data['Accessorial']) && !array_is_list($data['Accessorial'])) {
+                $data['Accessorial'] = [$data['Accessorial']];
+            }
+            if (isset($data['ItemizedCharges']) && !array_is_list($data['ItemizedCharges'])) {
+                $data['ItemizedCharges'] = [$data['ItemizedCharges']];
+            }
+            if (isset($data['RateModifier']) && !array_is_list($data['RateModifier'])) {
+                $data['RateModifier'] = [$data['RateModifier']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class RatedShipmentRatedPackageNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force fields to always be an array even when the API returns a single value
-        if (isset($data['Accessorial']) && ! array_is_list($data['Accessorial'])) {
-            $data['Accessorial'] = [$data['Accessorial']];
+            // Force fields to always be an array even when the API returns a single value
+            if (isset($data['Accessorial']) && !array_is_list($data['Accessorial'])) {
+                $data['Accessorial'] = [$data['Accessorial']];
+            }
+            if (isset($data['ItemizedCharges']) && !array_is_list($data['ItemizedCharges'])) {
+                $data['ItemizedCharges'] = [$data['ItemizedCharges']];
+            }
+            if (isset($data['RateModifier']) && !array_is_list($data['RateModifier'])) {
+                $data['RateModifier'] = [$data['RateModifier']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        if (isset($data['ItemizedCharges']) && ! array_is_list($data['ItemizedCharges'])) {
-            $data['ItemizedCharges'] = [$data['ItemizedCharges']];
-        }
-        if (isset($data['RateModifier']) && ! array_is_list($data['RateModifier'])) {
-            $data['RateModifier'] = [$data['RateModifier']];
-        }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/ResponseErrorNormalizer.php
+++ b/src/Normalizer/ResponseErrorNormalizer.php
@@ -3,27 +3,52 @@
 namespace ShipStream\Ups\Normalizer;
 
 use ShipStream\Ups\Api\Normalizer\ResponseErrorNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class ResponseErrorNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class ResponseErrorNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force fields to always be an array even when the API returns a single value
+            if (isset($data['ErrorLocation']) && !array_is_list($data['ErrorLocation'])) {
+                $data['ErrorLocation'] = [$data['ErrorLocation']];
+            }
+            if (isset($data['ErrorDigest']) && !is_array($data['ErrorDigest'])) {
+                $data['ErrorDigest'] = [$data['ErrorDigest']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class ResponseErrorNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force fields to always be an array even when the API returns a single value
-        if (isset($data['ErrorLocation']) && ! array_is_list($data['ErrorLocation'])) {
-            $data['ErrorLocation'] = [$data['ErrorLocation']];
+            // Force fields to always be an array even when the API returns a single value
+            if (isset($data['ErrorLocation']) && !array_is_list($data['ErrorLocation'])) {
+                $data['ErrorLocation'] = [$data['ErrorLocation']];
+            }
+            if (isset($data['ErrorDigest']) && !is_array($data['ErrorDigest'])) {
+                $data['ErrorDigest'] = [$data['ErrorDigest']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        if (isset($data['ErrorDigest']) && ! is_array($data['ErrorDigest'])) {
-            $data['ErrorDigest'] = [$data['ErrorDigest']];
-        }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/Shipping/ShipmentResponseResponseNormalizer.php
+++ b/src/Normalizer/Shipping/ShipmentResponseResponseNormalizer.php
@@ -8,25 +8,25 @@ use function array_is_list;
 use function is_array;
 
 if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
-class ShipmentResponseResponseNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    class ShipmentResponseResponseNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force Alert to always be an array even when the API returns a single value
+            // @see https://github.com/UPS-API/api-documentation/issues/3
+            if (isset($data['Alert']) && ! array_is_list($data['Alert'])) {
+                $data['Alert'] = [$data['Alert']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
-
-        // Force Alert to always be an array even when the API returns a single value
-        // @see https://github.com/UPS-API/api-documentation/issues/3
-        if (isset($data['Alert']) && ! array_is_list($data['Alert'])) {
-            $data['Alert'] = [$data['Alert']];
-        }
-        return parent::denormalize($data, $type, $format, $context);
     }
-}
 } else {
     class ShipmentResponseResponseNormalizer extends BaseNormalizer
     {
@@ -38,7 +38,7 @@ class ShipmentResponseResponseNormalizer extends BaseNormalizer
             if ($data === null || is_array($data) === false) {
                 return parent::denormalize($data, $type, $format, $context);
             }
-    
+
             // Force Alert to always be an array even when the API returns a single value
             // @see https://github.com/UPS-API/api-documentation/issues/3
             if (isset($data['Alert']) && ! array_is_list($data['Alert'])) {

--- a/src/Normalizer/Shipping/ShipmentResponseResponseNormalizer.php
+++ b/src/Normalizer/Shipping/ShipmentResponseResponseNormalizer.php
@@ -3,9 +3,11 @@
 namespace ShipStream\Ups\Normalizer\Shipping;
 
 use ShipStream\Ups\Api\Normalizer\ShipmentResponseResponseNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
 class ShipmentResponseResponseNormalizer extends BaseNormalizer
 {
     /**
@@ -24,4 +26,25 @@ class ShipmentResponseResponseNormalizer extends BaseNormalizer
         }
         return parent::denormalize($data, $type, $format, $context);
     }
+}
+} else {
+    class ShipmentResponseResponseNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+    
+            // Force Alert to always be an array even when the API returns a single value
+            // @see https://github.com/UPS-API/api-documentation/issues/3
+            if (isset($data['Alert']) && ! array_is_list($data['Alert'])) {
+                $data['Alert'] = [$data['Alert']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
+        }
+    }   
 }

--- a/src/Normalizer/Shipping/ShipmentResponseShipmentResultsNormalizer.php
+++ b/src/Normalizer/Shipping/ShipmentResponseShipmentResultsNormalizer.php
@@ -3,25 +3,48 @@
 namespace ShipStream\Ups\Normalizer\Shipping;
 
 use ShipStream\Ups\Api\Normalizer\ShipmentResponseShipmentResultsNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class ShipmentResponseShipmentResultsNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class ShipmentResponseShipmentResultsNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force PackageResults to always be an array even when the API returns a single value
+            // @see https://github.com/UPS-API/api-documentation/issues/3
+            if (isset($data['PackageResults']) && !array_is_list($data['PackageResults'])) {
+                $data['PackageResults'] = [$data['PackageResults']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class ShipmentResponseShipmentResultsNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force PackageResults to always be an array even when the API returns a single value
-        // @see https://github.com/UPS-API/api-documentation/issues/3
-        if (isset($data['PackageResults']) && ! array_is_list($data['PackageResults'])) {
-            $data['PackageResults'] = [$data['PackageResults']];
+            // Force PackageResults to always be an array even when the API returns a single value
+            // @see https://github.com/UPS-API/api-documentation/issues/3
+            if (isset($data['PackageResults']) && !array_is_list($data['PackageResults'])) {
+                $data['PackageResults'] = [$data['PackageResults']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/TForceFreightRating/FreightRateResponseNormalizer.php
+++ b/src/Normalizer/TForceFreightRating/FreightRateResponseNormalizer.php
@@ -3,30 +3,58 @@
 namespace ShipStream\Ups\Normalizer\TForceFreightRating;
 
 use ShipStream\Ups\Api\Normalizer\FreightRateResponseNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class FreightRateResponseNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class FreightRateResponseNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force fields to always be an array even when the API returns a single value
+            if (isset($data['Rate']) && !array_is_list($data['Rate'])) {
+                $data['Rate'] = [$data['Rate']];
+            }
+            if (isset($data['Commodity']) && !array_is_list($data['Commodity'])) {
+                $data['Commodity'] = [$data['Commodity']];
+            }
+            if (isset($data['AlternateRatesResponse']) && !array_is_list($data['AlternateRatesResponse'])) {
+                $data['AlternateRatesResponse'] = [$data['AlternateRatesResponse']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class FreightRateResponseNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force fields to always be an array even when the API returns a single value
-        if (isset($data['Rate']) && ! array_is_list($data['Rate'])) {
-            $data['Rate'] = [$data['Rate']];
+            // Force fields to always be an array even when the API returns a single value
+            if (isset($data['Rate']) && !array_is_list($data['Rate'])) {
+                $data['Rate'] = [$data['Rate']];
+            }
+            if (isset($data['Commodity']) && !array_is_list($data['Commodity'])) {
+                $data['Commodity'] = [$data['Commodity']];
+            }
+            if (isset($data['AlternateRatesResponse']) && !array_is_list($data['AlternateRatesResponse'])) {
+                $data['AlternateRatesResponse'] = [$data['AlternateRatesResponse']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        if (isset($data['Commodity']) && ! array_is_list($data['Commodity'])) {
-            $data['Commodity'] = [$data['Commodity']];
-        }
-        if (isset($data['AlternateRatesResponse']) && ! array_is_list($data['AlternateRatesResponse'])) {
-            $data['AlternateRatesResponse'] = [$data['AlternateRatesResponse']];
-        }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/TForceFreightRating/FreightRateResponseResponseNormalizer.php
+++ b/src/Normalizer/TForceFreightRating/FreightRateResponseResponseNormalizer.php
@@ -3,24 +3,46 @@
 namespace ShipStream\Ups\Normalizer\TForceFreightRating;
 
 use ShipStream\Ups\Api\Normalizer\FreightRateResponseResponseNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class FreightRateResponseResponseNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class FreightRateResponseResponseNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force Alert to always be an array even when the API returns a single value
+            if (isset($data['Alert']) && !array_is_list($data['Alert'])) {
+                $data['Alert'] = [$data['Alert']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
+    }
+} else {
+    class FreightRateResponseResponseNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
 
-        // Force Alert to always be an array even when the API returns a single value
-        if (isset($data['Alert']) && ! array_is_list($data['Alert'])) {
-            $data['Alert'] = [$data['Alert']];
+            // Force Alert to always be an array even when the API returns a single value
+            if (isset($data['Alert']) && !array_is_list($data['Alert'])) {
+                $data['Alert'] = [$data['Alert']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }

--- a/src/Normalizer/TForceFreightShipping/FreightShipResponseShipmentResultsNormalizer.php
+++ b/src/Normalizer/TForceFreightShipping/FreightShipResponseShipmentResultsNormalizer.php
@@ -8,41 +8,41 @@ use function array_is_list;
 use function is_array;
 
 if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
-class FreightShipResponseShipmentResultsNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    class FreightShipResponseShipmentResultsNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force Rate to always be an array even when the API returns a single value
+            if (isset($data['Rate']) && ! array_is_list($data['Rate'])) {
+                $data['Rate'] = [$data['Rate']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
-
-        // Force Rate to always be an array even when the API returns a single value
-        if (isset($data['Rate']) && ! array_is_list($data['Rate'])) {
-            $data['Rate'] = [$data['Rate']];
-        }
-        return parent::denormalize($data, $type, $format, $context);
     }
-}
 } else {
     class FreightShipResponseShipmentResultsNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize($data, $type, $format = null, array $context = [])
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+
+            // Force Rate to always be an array even when the API returns a single value
+            if (isset($data['Rate']) && ! array_is_list($data['Rate'])) {
+                $data['Rate'] = [$data['Rate']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
-
-        // Force Rate to always be an array even when the API returns a single value
-        if (isset($data['Rate']) && ! array_is_list($data['Rate'])) {
-            $data['Rate'] = [$data['Rate']];
-        }
-        return parent::denormalize($data, $type, $format, $context);
     }
-}
 }

--- a/src/Normalizer/TForceFreightShipping/FreightShipResponseShipmentResultsNormalizer.php
+++ b/src/Normalizer/TForceFreightShipping/FreightShipResponseShipmentResultsNormalizer.php
@@ -3,9 +3,11 @@
 namespace ShipStream\Ups\Normalizer\TForceFreightShipping;
 
 use ShipStream\Ups\Api\Normalizer\FreightShipResponseShipmentResultsNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
 class FreightShipResponseShipmentResultsNormalizer extends BaseNormalizer
 {
     /**
@@ -23,4 +25,24 @@ class FreightShipResponseShipmentResultsNormalizer extends BaseNormalizer
         }
         return parent::denormalize($data, $type, $format, $context);
     }
+}
+} else {
+    class FreightShipResponseShipmentResultsNormalizer extends BaseNormalizer
+{
+    /**
+     * @inheritDoc
+     */
+    public function denormalize($data, $type, $format = null, array $context = [])
+    {
+        if ($data === null || is_array($data) === false) {
+            return parent::denormalize($data, $type, $format, $context);
+        }
+
+        // Force Rate to always be an array even when the API returns a single value
+        if (isset($data['Rate']) && ! array_is_list($data['Rate'])) {
+            $data['Rate'] = [$data['Rate']];
+        }
+        return parent::denormalize($data, $type, $format, $context);
+    }
+}
 }

--- a/src/Normalizer/TForceFreightShipping/ShipmentResultsDocumentsNormalizer.php
+++ b/src/Normalizer/TForceFreightShipping/ShipmentResultsDocumentsNormalizer.php
@@ -8,7 +8,7 @@ use function array_is_list;
 use function is_array;
 
 if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
-    class ResponseErrorNormalizer extends BaseNormalizer
+    class ShipmentResultsDocumentsNormalizer extends BaseNormalizer
     {
         /**
          * @inheritDoc
@@ -18,19 +18,19 @@ if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR
             if ($data === null || is_array($data) === false) {
                 return parent::denormalize($data, $type, $format, $context);
             }
-    
+
             // Force fields to always be an array even when the API returns a single value
-            if (isset($data['ErrorLocation']) && ! array_is_list($data['ErrorLocation'])) {
-                $data['ErrorLocation'] = [$data['ErrorLocation']];
+            if (isset($data['Image']) && ! array_is_list($data['Image'])) {
+                $data['Image'] = [$data['Image']];
             }
-            if (isset($data['ErrorDigest']) && ! is_array($data['ErrorDigest'])) {
-                $data['ErrorDigest'] = [$data['ErrorDigest']];
+            if (isset($data['Forms']) && ! array_is_list($data['Forms'])) {
+                $data['Forms'] = [$data['Forms']];
             }
             return parent::denormalize($data, $type, $format, $context);
         }
     }
 } else {
-    class ResponseErrorNormalizer extends BaseNormalizer
+    class ShipmentResultsDocumentsNormalizer extends BaseNormalizer
     {
         /**
          * @inheritDoc
@@ -40,13 +40,13 @@ if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR
             if ($data === null || is_array($data) === false) {
                 return parent::denormalize($data, $type, $format, $context);
             }
-    
+
             // Force fields to always be an array even when the API returns a single value
-            if (isset($data['ErrorLocation']) && ! array_is_list($data['ErrorLocation'])) {
-                $data['ErrorLocation'] = [$data['ErrorLocation']];
+            if (isset($data['Image']) && ! array_is_list($data['Image'])) {
+                $data['Image'] = [$data['Image']];
             }
-            if (isset($data['ErrorDigest']) && ! is_array($data['ErrorDigest'])) {
-                $data['ErrorDigest'] = [$data['ErrorDigest']];
+            if (isset($data['Forms']) && ! array_is_list($data['Forms'])) {
+                $data['Forms'] = [$data['Forms']];
             }
             return parent::denormalize($data, $type, $format, $context);
         }

--- a/src/Normalizer/TForceFreightShipping/ShipmentResultsDocumentsNormalizer.php
+++ b/src/Normalizer/TForceFreightShipping/ShipmentResultsDocumentsNormalizer.php
@@ -3,27 +3,52 @@
 namespace ShipStream\Ups\Normalizer\TForceFreightShipping;
 
 use ShipStream\Ups\Api\Normalizer\ShipmentResultsDocumentsNormalizer as BaseNormalizer;
+use Symfony\Component\HttpKernel\Kernel;
 use function array_is_list;
 use function is_array;
 
-class ShipmentResultsDocumentsNormalizer extends BaseNormalizer
-{
-    /**
-     * @inheritDoc
-     */
-    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class ResponseErrorNormalizer extends BaseNormalizer
     {
-        if ($data === null || is_array($data) === false) {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+    
+            // Force fields to always be an array even when the API returns a single value
+            if (isset($data['ErrorLocation']) && ! array_is_list($data['ErrorLocation'])) {
+                $data['ErrorLocation'] = [$data['ErrorLocation']];
+            }
+            if (isset($data['ErrorDigest']) && ! is_array($data['ErrorDigest'])) {
+                $data['ErrorDigest'] = [$data['ErrorDigest']];
+            }
             return parent::denormalize($data, $type, $format, $context);
         }
-
-        // Force fields to always be an array even when the API returns a single value
-        if (isset($data['Image']) && ! array_is_list($data['Image'])) {
-            $data['Image'] = [$data['Image']];
+    }
+} else {
+    class ResponseErrorNormalizer extends BaseNormalizer
+    {
+        /**
+         * @inheritDoc
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if ($data === null || is_array($data) === false) {
+                return parent::denormalize($data, $type, $format, $context);
+            }
+    
+            // Force fields to always be an array even when the API returns a single value
+            if (isset($data['ErrorLocation']) && ! array_is_list($data['ErrorLocation'])) {
+                $data['ErrorLocation'] = [$data['ErrorLocation']];
+            }
+            if (isset($data['ErrorDigest']) && ! is_array($data['ErrorDigest'])) {
+                $data['ErrorDigest'] = [$data['ErrorDigest']];
+            }
+            return parent::denormalize($data, $type, $format, $context);
         }
-        if (isset($data['Forms']) && ! array_is_list($data['Forms'])) {
-            $data['Forms'] = [$data['Forms']];
-        }
-        return parent::denormalize($data, $type, $format, $context);
     }
 }


### PR DESCRIPTION
**Issue:**
The Normalizers introduced in `ShipStream\Ups\Normalizer` can produce a Fatal Error due to method signature mismatch when used in a project that has `Symfony\Component\HttpKernel\Kernel` or are not using a `Kernel::MAJOR_VERSION` greater than 7 or is equal to 6 with a `Kernel::MINOR_VERSION` of 4.

This is because to the `ShipStream\Ups\Normalizer` classes define one class with typehints in its methods which only covers one possible class definition provided by the base normalizers defined by the `ShipStream\Ups\Api\Normalizer` namespace.

This pull request introduces a second class definition to each normalizer defined in `ShipStream\Ups\Normalizer` that matches the second class definition in the `ShipStream\Ups\Api\Normalizer` namespace.

**Notes**

I do not know if this is the best approach as this requires a lot of manual work every time someone defines a new custom normalizer in the `ShipStream\Ups\Normalizer` namespace.

It may be possible to treat the `ShipStream\Ups\Normalizer` objects as proxy objects for the normalizers in `ShipStream\Ups\Api\Normalizer` which would make it less of a maintenance issue going forward however I am not versed well enough in how JanePHP and the Symfony Serializer Component use normalizers to make that call.

i.e.

```
<?php

namespace ShipStream\Ups\Normalizer;
use Symfony\Component\Serializer\Encoder\NormalizationAwareInterface;
use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;

class NormalizerClassName implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizationAwareInterface
{

    protected $normalizer;

    public function __construct()
    {
        $this->normalizer = new BaseNormalizer();
    }

    public function denormalize(mixed $data, $class, $format = null, array $context = array())
    {
        // Manipulate the data before passing it to the base normalizer.
        return $this->normalizer->denormalize($data, $class, $format, $context);
    }

    public function supportsDenormalization($data, $type, $format = null)
    {
        return $this->normalizer->supportsDenormalization($data, $type, $format);
    }

    public function normalize($object, $format = null, array $context = array())
    {
        return $this->normalizer->normalize($object, $format, $context);
    }

    public function supportsNormalization($data, $format = null)
    {
        return $this->normalizer->supportsNormalization($data, $format);
    }
}
```