### PR TITLE
Make CandidateAddressKeyFormat fields nullable

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9229,36 +9229,42 @@ components:
           items:
             type: string
           description: 'Address line (street number, street name and street type, and political division 1, political division 2 and postal code) used for street level information. Additional secondary information (apartment, suite, floor, etc.) Applicable to US and PR only.  Not returned if user selects the RegionalRequestIndicator.'
+          nullable: true
         Region:
           maximum: 1
           maxLength: 100
           minLength: 1
           type: string
           description: 'Single entry containing in this order  Political Division 2, Political Division 1 and Post Code Primary Low and/or PostcodeExtendedLow.'
+          nullable: true
         PoliticalDivision2:
           maximum: 1
           maxLength: 30
           minLength: 1
           type: string
           description: 'City or Town name.'
+          nullable: true
         PoliticalDivision1:
           maximum: 1
           maxLength: 30
           minLength: 1
           type: string
           description: 'State/Province.  Returned if the location is within a State/Province/Territory. For International: returned if user enters valid Country or Territory Code, and City/postal code and it has a match.  For Domestic addresses, the value must be a valid 2-character value (per US Mail standards).  For International the full State or Province name will be returned.'
+          nullable: true
         PostcodePrimaryLow:
           maximum: 1
           maxLength: 10
           minLength: 1
           type: string
           description: 'Low-end Postal Code. Returned for countries or territories with Postal Codes. May be alphanumeric.'
+          nullable: true
         PostcodeExtendedLow:
           maximum: 1
           maxLength: 10
           minLength: 1
           type: string
           description: "Low-end extended postal code in a range. Example in quotes: Postal Code 30076-'1234'.  Only returned in candidate list. May be alphanumeric"
+          nullable: true
         Urbanization:
           maximum: 1
           maxLength: 30

--- a/openapi/AddressValidation.yaml
+++ b/openapi/AddressValidation.yaml
@@ -679,6 +679,7 @@ components:
           maxLength: 100
           items:
             type: string
+          nullable: true
         Region:
           description: Single entry containing in this order  Political Division 2,
             Political Division 1 and Post Code Primary Low and/or PostcodeExtendedLow.
@@ -686,12 +687,14 @@ components:
           type: string
           minLength: 1
           maxLength: 100
+          nullable: true
         PoliticalDivision2:
           description: City or Town name.
           maximum: 1
           type: string
           minLength: 1
           maxLength: 30
+          nullable: true
         PoliticalDivision1:
           description: "State/Province.  Returned if the location is within a State/Province/Territory.
              For International: returned if user enters valid Country or Territory
@@ -702,6 +705,7 @@ components:
           type: string
           minLength: 1
           maxLength: 30
+          nullable: true
         PostcodePrimaryLow:
           description: Low-end Postal Code. Returned for countries or territories
             with Postal Codes. May be alphanumeric.
@@ -709,6 +713,7 @@ components:
           type: string
           minLength: 1
           maxLength: 10
+          nullable: true
         PostcodeExtendedLow:
           description: "Low-end extended postal code in a range. Example in quotes:
             Postal Code 30076-'1234'.  Only returned in candidate list. May be alphanumeric"
@@ -716,6 +721,7 @@ components:
           type: string
           minLength: 1
           maxLength: 10
+          nullable: true
         Urbanization:
           description: Puerto Rico Political Division 3. Only Valid for Puerto Rico.
           maximum: 1

--- a/src/Api/Model/CandidateAddressKeyFormat.php
+++ b/src/Api/Model/CandidateAddressKeyFormat.php
@@ -27,37 +27,37 @@ class CandidateAddressKeyFormat extends \ArrayObject
     /**
      * Address line (street number, street name and street type, and political division 1, political division 2 and postal code) used for street level information. Additional secondary information (apartment, suite, floor, etc.) Applicable to US and PR only.  Not returned if user selects the RegionalRequestIndicator.
      *
-     * @var list<string>
+     * @var list<string>|null
      */
     protected $addressLine;
     /**
      * Single entry containing in this order  Political Division 2, Political Division 1 and Post Code Primary Low and/or PostcodeExtendedLow.
      *
-     * @var string
+     * @var string|null
      */
     protected $region;
     /**
      * City or Town name.
      *
-     * @var string
+     * @var string|null
      */
     protected $politicalDivision2;
     /**
      * State/Province.  Returned if the location is within a State/Province/Territory. For International: returned if user enters valid Country or Territory Code, and City/postal code and it has a match.  For Domestic addresses, the value must be a valid 2-character value (per US Mail standards).  For International the full State or Province name will be returned.
      *
-     * @var string
+     * @var string|null
      */
     protected $politicalDivision1;
     /**
      * Low-end Postal Code. Returned for countries or territories with Postal Codes. May be alphanumeric.
      *
-     * @var string
+     * @var string|null
      */
     protected $postcodePrimaryLow;
     /**
      * Low-end extended postal code in a range. Example in quotes: Postal Code 30076-'1234'.  Only returned in candidate list. May be alphanumeric
      *
-     * @var string
+     * @var string|null
      */
     protected $postcodeExtendedLow;
     /**
@@ -119,20 +119,20 @@ class CandidateAddressKeyFormat extends \ArrayObject
     /**
      * Address line (street number, street name and street type, and political division 1, political division 2 and postal code) used for street level information. Additional secondary information (apartment, suite, floor, etc.) Applicable to US and PR only.  Not returned if user selects the RegionalRequestIndicator.
      *
-     * @return list<string>
+     * @return list<string>|null
      */
-    public function getAddressLine(): array
+    public function getAddressLine(): ?array
     {
         return $this->addressLine;
     }
     /**
      * Address line (street number, street name and street type, and political division 1, political division 2 and postal code) used for street level information. Additional secondary information (apartment, suite, floor, etc.) Applicable to US and PR only.  Not returned if user selects the RegionalRequestIndicator.
      *
-     * @param list<string> $addressLine
+     * @param list<string>|null $addressLine
      *
      * @return self
      */
-    public function setAddressLine(array $addressLine): self
+    public function setAddressLine(?array $addressLine): self
     {
         $this->initialized['addressLine'] = true;
         $this->addressLine = $addressLine;
@@ -141,20 +141,20 @@ class CandidateAddressKeyFormat extends \ArrayObject
     /**
      * Single entry containing in this order  Political Division 2, Political Division 1 and Post Code Primary Low and/or PostcodeExtendedLow.
      *
-     * @return string
+     * @return string|null
      */
-    public function getRegion(): string
+    public function getRegion(): ?string
     {
         return $this->region;
     }
     /**
      * Single entry containing in this order  Political Division 2, Political Division 1 and Post Code Primary Low and/or PostcodeExtendedLow.
      *
-     * @param string $region
+     * @param string|null $region
      *
      * @return self
      */
-    public function setRegion(string $region): self
+    public function setRegion(?string $region): self
     {
         $this->initialized['region'] = true;
         $this->region = $region;
@@ -163,20 +163,20 @@ class CandidateAddressKeyFormat extends \ArrayObject
     /**
      * City or Town name.
      *
-     * @return string
+     * @return string|null
      */
-    public function getPoliticalDivision2(): string
+    public function getPoliticalDivision2(): ?string
     {
         return $this->politicalDivision2;
     }
     /**
      * City or Town name.
      *
-     * @param string $politicalDivision2
+     * @param string|null $politicalDivision2
      *
      * @return self
      */
-    public function setPoliticalDivision2(string $politicalDivision2): self
+    public function setPoliticalDivision2(?string $politicalDivision2): self
     {
         $this->initialized['politicalDivision2'] = true;
         $this->politicalDivision2 = $politicalDivision2;
@@ -185,20 +185,20 @@ class CandidateAddressKeyFormat extends \ArrayObject
     /**
      * State/Province.  Returned if the location is within a State/Province/Territory. For International: returned if user enters valid Country or Territory Code, and City/postal code and it has a match.  For Domestic addresses, the value must be a valid 2-character value (per US Mail standards).  For International the full State or Province name will be returned.
      *
-     * @return string
+     * @return string|null
      */
-    public function getPoliticalDivision1(): string
+    public function getPoliticalDivision1(): ?string
     {
         return $this->politicalDivision1;
     }
     /**
      * State/Province.  Returned if the location is within a State/Province/Territory. For International: returned if user enters valid Country or Territory Code, and City/postal code and it has a match.  For Domestic addresses, the value must be a valid 2-character value (per US Mail standards).  For International the full State or Province name will be returned.
      *
-     * @param string $politicalDivision1
+     * @param string|null $politicalDivision1
      *
      * @return self
      */
-    public function setPoliticalDivision1(string $politicalDivision1): self
+    public function setPoliticalDivision1(?string $politicalDivision1): self
     {
         $this->initialized['politicalDivision1'] = true;
         $this->politicalDivision1 = $politicalDivision1;
@@ -207,20 +207,20 @@ class CandidateAddressKeyFormat extends \ArrayObject
     /**
      * Low-end Postal Code. Returned for countries or territories with Postal Codes. May be alphanumeric.
      *
-     * @return string
+     * @return string|null
      */
-    public function getPostcodePrimaryLow(): string
+    public function getPostcodePrimaryLow(): ?string
     {
         return $this->postcodePrimaryLow;
     }
     /**
      * Low-end Postal Code. Returned for countries or territories with Postal Codes. May be alphanumeric.
      *
-     * @param string $postcodePrimaryLow
+     * @param string|null $postcodePrimaryLow
      *
      * @return self
      */
-    public function setPostcodePrimaryLow(string $postcodePrimaryLow): self
+    public function setPostcodePrimaryLow(?string $postcodePrimaryLow): self
     {
         $this->initialized['postcodePrimaryLow'] = true;
         $this->postcodePrimaryLow = $postcodePrimaryLow;
@@ -229,20 +229,20 @@ class CandidateAddressKeyFormat extends \ArrayObject
     /**
      * Low-end extended postal code in a range. Example in quotes: Postal Code 30076-'1234'.  Only returned in candidate list. May be alphanumeric
      *
-     * @return string
+     * @return string|null
      */
-    public function getPostcodeExtendedLow(): string
+    public function getPostcodeExtendedLow(): ?string
     {
         return $this->postcodeExtendedLow;
     }
     /**
      * Low-end extended postal code in a range. Example in quotes: Postal Code 30076-'1234'.  Only returned in candidate list. May be alphanumeric
      *
-     * @param string $postcodeExtendedLow
+     * @param string|null $postcodeExtendedLow
      *
      * @return self
      */
-    public function setPostcodeExtendedLow(string $postcodeExtendedLow): self
+    public function setPostcodeExtendedLow(?string $postcodeExtendedLow): self
     {
         $this->initialized['postcodeExtendedLow'] = true;
         $this->postcodeExtendedLow = $postcodeExtendedLow;

--- a/src/Api/Normalizer/CandidateAddressKeyFormatNormalizer.php
+++ b/src/Api/Normalizer/CandidateAddressKeyFormatNormalizer.php
@@ -27,15 +27,15 @@ class CandidateAddressKeyFormatNormalizer implements DenormalizerInterface, Norm
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \ShipStream\Ups\Api\Model\CandidateAddressKeyFormat();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
-        }
-        $object = new \ShipStream\Ups\Api\Model\CandidateAddressKeyFormat();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
         }
         if (\array_key_exists('ConsigneeName', $data) && $data['ConsigneeName'] !== null) {
             $object->setConsigneeName($data['ConsigneeName']);
@@ -51,7 +51,7 @@ class CandidateAddressKeyFormatNormalizer implements DenormalizerInterface, Norm
         elseif (\array_key_exists('AttentionName', $data) && $data['AttentionName'] === null) {
             $object->setAttentionName(null);
         }
-        if (\array_key_exists('AddressLine', $data)) {
+        if (\array_key_exists('AddressLine', $data) && $data['AddressLine'] !== null) {
             $values = [];
             foreach ($data['AddressLine'] as $value) {
                 $values[] = $value;
@@ -59,25 +59,43 @@ class CandidateAddressKeyFormatNormalizer implements DenormalizerInterface, Norm
             $object->setAddressLine($values);
             unset($data['AddressLine']);
         }
-        if (\array_key_exists('Region', $data)) {
+        elseif (\array_key_exists('AddressLine', $data) && $data['AddressLine'] === null) {
+            $object->setAddressLine(null);
+        }
+        if (\array_key_exists('Region', $data) && $data['Region'] !== null) {
             $object->setRegion($data['Region']);
             unset($data['Region']);
         }
-        if (\array_key_exists('PoliticalDivision2', $data)) {
+        elseif (\array_key_exists('Region', $data) && $data['Region'] === null) {
+            $object->setRegion(null);
+        }
+        if (\array_key_exists('PoliticalDivision2', $data) && $data['PoliticalDivision2'] !== null) {
             $object->setPoliticalDivision2($data['PoliticalDivision2']);
             unset($data['PoliticalDivision2']);
         }
-        if (\array_key_exists('PoliticalDivision1', $data)) {
+        elseif (\array_key_exists('PoliticalDivision2', $data) && $data['PoliticalDivision2'] === null) {
+            $object->setPoliticalDivision2(null);
+        }
+        if (\array_key_exists('PoliticalDivision1', $data) && $data['PoliticalDivision1'] !== null) {
             $object->setPoliticalDivision1($data['PoliticalDivision1']);
             unset($data['PoliticalDivision1']);
         }
-        if (\array_key_exists('PostcodePrimaryLow', $data)) {
+        elseif (\array_key_exists('PoliticalDivision1', $data) && $data['PoliticalDivision1'] === null) {
+            $object->setPoliticalDivision1(null);
+        }
+        if (\array_key_exists('PostcodePrimaryLow', $data) && $data['PostcodePrimaryLow'] !== null) {
             $object->setPostcodePrimaryLow($data['PostcodePrimaryLow']);
             unset($data['PostcodePrimaryLow']);
         }
-        if (\array_key_exists('PostcodeExtendedLow', $data)) {
+        elseif (\array_key_exists('PostcodePrimaryLow', $data) && $data['PostcodePrimaryLow'] === null) {
+            $object->setPostcodePrimaryLow(null);
+        }
+        if (\array_key_exists('PostcodeExtendedLow', $data) && $data['PostcodeExtendedLow'] !== null) {
             $object->setPostcodeExtendedLow($data['PostcodeExtendedLow']);
             unset($data['PostcodeExtendedLow']);
+        }
+        elseif (\array_key_exists('PostcodeExtendedLow', $data) && $data['PostcodeExtendedLow'] === null) {
+            $object->setPostcodeExtendedLow(null);
         }
         if (\array_key_exists('Urbanization', $data) && $data['Urbanization'] !== null) {
             $object->setUrbanization($data['Urbanization']);
@@ -106,26 +124,26 @@ class CandidateAddressKeyFormatNormalizer implements DenormalizerInterface, Norm
         if ($data->isInitialized('attentionName')) {
             $dataArray['AttentionName'] = $data->getAttentionName();
         }
-        if ($data->isInitialized('addressLine') && null !== $data->getAddressLine()) {
+        if ($data->isInitialized('addressLine')) {
             $values = [];
             foreach ($data->getAddressLine() as $value) {
                 $values[] = $value;
             }
             $dataArray['AddressLine'] = $values;
         }
-        if ($data->isInitialized('region') && null !== $data->getRegion()) {
+        if ($data->isInitialized('region')) {
             $dataArray['Region'] = $data->getRegion();
         }
-        if ($data->isInitialized('politicalDivision2') && null !== $data->getPoliticalDivision2()) {
+        if ($data->isInitialized('politicalDivision2')) {
             $dataArray['PoliticalDivision2'] = $data->getPoliticalDivision2();
         }
-        if ($data->isInitialized('politicalDivision1') && null !== $data->getPoliticalDivision1()) {
+        if ($data->isInitialized('politicalDivision1')) {
             $dataArray['PoliticalDivision1'] = $data->getPoliticalDivision1();
         }
-        if ($data->isInitialized('postcodePrimaryLow') && null !== $data->getPostcodePrimaryLow()) {
+        if ($data->isInitialized('postcodePrimaryLow')) {
             $dataArray['PostcodePrimaryLow'] = $data->getPostcodePrimaryLow();
         }
-        if ($data->isInitialized('postcodeExtendedLow') && null !== $data->getPostcodeExtendedLow()) {
+        if ($data->isInitialized('postcodeExtendedLow')) {
             $dataArray['PostcodeExtendedLow'] = $data->getPostcodeExtendedLow();
         }
         if ($data->isInitialized('urbanization')) {


### PR DESCRIPTION
Per the UPS Address Validation (XAV) API spec, only `CountryCode` is required to be returned in a Candidate AddressKeyFormat. All other fields are conditionally returned and may be omitted depending on the address type and match granularity:

- `AddressLine`, `Region`, `PoliticalDivision2`, `PoliticalDivision1`: omitted for regional/international matches that don't resolve to that granularity
- `PostcodePrimaryLow`: "Returned for countries or territories with Postal Codes"
- `PostcodeExtendedLow`: "Only returned in candidate list" and only for countries that use range-style extensions (effectively US only)

Production saw `TypeError: getPoliticalDivision2(): Return value must be of type string, null returned` and the equivalent for `getPostcodeExtendedLow()` when UPS returned candidates missing these fields. Marking them `nullable: true` in the OpenAPI spec lets Jane emit `?string` return types so the SDK no longer trips PHP 8.2 strict return checks on valid upstream responses.